### PR TITLE
Change resolving classes to use the app helper instead of resolve. Th…

### DIFF
--- a/src/Builders/Components/CallbacksBuilder.php
+++ b/src/Builders/Components/CallbacksBuilder.php
@@ -20,7 +20,7 @@ class CallbacksBuilder extends Builder
             })
             ->map(static function ($class) {
                 /** @var CallbackFactory $instance */
-                $instance = resolve($class);
+                $instance = app($class);
 
                 return $instance->build();
             })

--- a/src/Builders/Components/RequestBodiesBuilder.php
+++ b/src/Builders/Components/RequestBodiesBuilder.php
@@ -20,7 +20,7 @@ class RequestBodiesBuilder extends Builder
             })
             ->map(static function ($class) {
                 /** @var RequestBodyFactory $instance */
-                $instance = resolve($class);
+                $instance = app($class);
 
                 return $instance->build();
             })

--- a/src/Builders/Components/ResponsesBuilder.php
+++ b/src/Builders/Components/ResponsesBuilder.php
@@ -20,7 +20,7 @@ class ResponsesBuilder extends Builder
             })
             ->map(static function ($class) {
                 /** @var ResponseFactory $instance */
-                $instance = resolve($class);
+                $instance = app($class);
 
                 return $instance->build();
             })

--- a/src/Builders/Components/SchemasBuilder.php
+++ b/src/Builders/Components/SchemasBuilder.php
@@ -20,7 +20,7 @@ class SchemasBuilder extends Builder
             })
             ->map(static function ($class) {
                 /** @var SchemaFactory $instance */
-                $instance = resolve($class);
+                $instance = app($class);
 
                 return $instance->build();
             })

--- a/src/Builders/Components/SecuritySchemesBuilder.php
+++ b/src/Builders/Components/SecuritySchemesBuilder.php
@@ -17,7 +17,7 @@ class SecuritySchemesBuilder extends Builder
             })
             ->map(static function ($class) {
                 /** @var SecuritySchemeFactory $instance */
-                $instance = resolve($class);
+                $instance = app($class);
 
                 return $instance->build();
             })

--- a/src/Builders/ExtensionsBuilder.php
+++ b/src/Builders/ExtensionsBuilder.php
@@ -18,7 +18,7 @@ class ExtensionsBuilder
             ->each(static function (ExtensionAnnotation $annotation) use ($object): void {
                 if ($annotation->factory) {
                     /** @var ExtensionFactory $factory */
-                    $factory = resolve($annotation->factory);
+                    $factory = app($annotation->factory);
                     $key = $factory->key();
                     $value = $factory->value();
                 } else {

--- a/src/Builders/Paths/Operation/CallbacksBuilder.php
+++ b/src/Builders/Paths/Operation/CallbacksBuilder.php
@@ -16,7 +16,7 @@ class CallbacksBuilder
                 return $annotation instanceof CallbackAnnotation;
             })
             ->map(static function (CallbackAnnotation $annotation) {
-                $factory = resolve($annotation->factory);
+                $factory = app($annotation->factory);
                 $pathItem = $factory->build();
 
                 if ($factory instanceof Reusable) {

--- a/src/Builders/Paths/Operation/ParametersBuilder.php
+++ b/src/Builders/Paths/Operation/ParametersBuilder.php
@@ -61,7 +61,7 @@ class ParametersBuilder
 
         if ($parameters) {
             /** @var ParametersFactory $parametersFactory */
-            $parametersFactory = resolve($parameters->factory);
+            $parametersFactory = app($parameters->factory);
 
             $parameters = $parametersFactory->build();
         }

--- a/src/Builders/Paths/Operation/RequestBodyBuilder.php
+++ b/src/Builders/Paths/Operation/RequestBodyBuilder.php
@@ -19,7 +19,7 @@ class RequestBodyBuilder
 
         if ($requestBody) {
             /** @var RequestBodyFactory $requestBodyFactory */
-            $requestBodyFactory = resolve($requestBody->factory);
+            $requestBodyFactory = app($requestBody->factory);
 
             $requestBody = $requestBodyFactory->build();
 

--- a/src/Builders/Paths/Operation/ResponsesBuilder.php
+++ b/src/Builders/Paths/Operation/ResponsesBuilder.php
@@ -16,7 +16,7 @@ class ResponsesBuilder
                 return $annotation instanceof ResponseAnnotation;
             })
             ->map(static function (ResponseAnnotation $annotation) {
-                $factory = resolve($annotation->factory);
+                $factory = app($annotation->factory);
                 $response = $factory->build();
 
                 if ($factory instanceof Reusable) {

--- a/src/Builders/PathsBuilder.php
+++ b/src/Builders/PathsBuilder.php
@@ -48,7 +48,7 @@ class PathsBuilder
             })
             ->map(static function (RouteInformation $item) use ($middlewares) {
                 foreach ($middlewares as $middleware) {
-                    resolve($middleware)->before($item);
+                    app($middleware)->before($item);
                 }
 
                 return $item;
@@ -65,7 +65,7 @@ class PathsBuilder
             })
             ->map(static function (PathItem $item) use ($middlewares) {
                 foreach ($middlewares as $middleware) {
-                    $item = resolve($middleware)->after($item);
+                    $item = app($middleware)->after($item);
                 }
 
                 return $item;

--- a/src/Concerns/Referencable.php
+++ b/src/Concerns/Referencable.php
@@ -16,7 +16,7 @@ trait Referencable
 {
     public static function ref(?string $objectId = null): Schema
     {
-        $instance = resolve(static::class);
+        $instance = app(static::class);
 
         if (! $instance instanceof Reusable) {
             throw new InvalidArgumentException('"'.static::class.'" must implement "'.Reusable::class.'" in order to be referencable.');

--- a/src/Console/SchemaFactoryMakeCommand.php
+++ b/src/Console/SchemaFactoryMakeCommand.php
@@ -42,7 +42,7 @@ class SchemaFactoryMakeCommand extends GeneratorCommand
         }
 
         /** @var Model $model */
-        $model = resolve($model);
+        $model = app($model);
 
         $columns = SchemaFacade::connection($model->getConnectionName())->getColumnListing($model->getTable());
         $connection = $model->getConnection();


### PR DESCRIPTION
…is is due to a conflict with Hoa.

We are using a package that depends on hoa/protocol. This package also registers a helper called `resolve` which returns a string that is a path to a class name, instead I have used the `app` helper which resolves this issue. 

Happy to hear feedback if this is a stupid idea.