### PR TITLE
Add custom paths to the configuration file

### DIFF
--- a/config/openapi.php
+++ b/config/openapi.php
@@ -7,9 +7,9 @@ return [
         'default' => [
 
             'info' => [
-                'title' => config('app.name'),
+                'title'       => config('app.name'),
                 'description' => null,
-                'version' => '1.0.0',
+                'version'     => '1.0.0',
             ],
 
             'servers' => [
@@ -27,14 +27,14 @@ return [
 
             ],
 
-            'security' => [
+            'security'    => [
                 // GoldSpecDigital\ObjectOrientedOAS\Objects\SecurityRequirement::create()->securityScheme('JWT'),
             ],
 
             // Route for exposing specification.
             // Leave uri null to disable.
-            'route' => [
-                'uri' => '/openapi',
+            'route'       => [
+                'uri'        => '/openapi',
                 'middleware' => [],
             ],
 
@@ -47,6 +47,28 @@ return [
 
         ],
 
+    ],
+
+    'paths' => [
+        'callbacks' => [
+            //
+        ],
+
+        'request_bodies' => [
+            //
+        ],
+
+        'responses' => [
+            //
+        ],
+
+        'schemas' => [
+            //
+        ],
+
+        'security_schemes' => [
+            //
+        ],
     ],
 
 ];

--- a/src/OpenApiServiceProvider.php
+++ b/src/OpenApiServiceProvider.php
@@ -24,7 +24,7 @@ class OpenApiServiceProvider extends ServiceProvider
     {
         if ($this->app->runningInConsole()) {
             $this->publishes([
-                __DIR__ . '/../config/openapi.php' => config_path('openapi.php'),
+                __DIR__.'/../config/openapi.php' => config_path('openapi.php'),
             ], 'openapi-config');
         }
 
@@ -49,13 +49,13 @@ class OpenApiServiceProvider extends ServiceProvider
             );
         });
 
-        $this->loadRoutesFrom(__DIR__ . '/../routes/api.php');
+        $this->loadRoutesFrom(__DIR__.'/../routes/api.php');
     }
 
     public function register(): void
     {
         $this->mergeConfigFrom(
-            __DIR__ . '/../config/openapi.php',
+            __DIR__.'/../config/openapi.php',
             'openapi'
         );
 
@@ -78,7 +78,7 @@ class OpenApiServiceProvider extends ServiceProvider
 
     protected function registerAnnotations(): void
     {
-        $files = glob(__DIR__ . '/Annotations/*.php');
+        $files = glob(__DIR__.'/Annotations/*.php');
 
         foreach ($files as $file) {
             AnnotationRegistry::registerFile($file);


### PR DESCRIPTION
This PR allows new directories for each OpenAPI resource (such as Responses, Schemas, RequestBodies, SecuritySchemes etc.) to be included, using the configuration file `config/openapi.php`.

This ensures that projects that work with different project structures do not depend exclusively on the `app/OpenAPI` directory.

Furthermore, patterns can be used to directory matching.

Example:

```php
<?php // config/openapi.php
return [
    // ...

   'paths' => [
        'callbacks' => [
            'OpenApi/Domains/*/Callbacks',
        ],

        'request_bodies' => [
            'OpenApi/Domains/*/RequestBodies',
        ],

        'responses' => [
            'OpenApi/Domains/*/Responses',
        ],

        'schemas' => [
            'OpenApi/Domains/*/Schemas',
        ],

        'security_schemes' => [
            'OpenApi/Domains/*/SecuritySchemes',
        ],
    ],
];
```