### PR TITLE
Update to route parameter annotations

### DIFF
--- a/src/Builders/Paths/Operation/ParametersBuilder.php
+++ b/src/Builders/Paths/Operation/ParametersBuilder.php
@@ -36,7 +36,9 @@ class ParametersBuilder
                     });
 
                 // The reflected param has no type, so ignore (should be defined in a ParametersFactory instead)
-                if($reflectionParameter && $reflectionParameter->getType() == null) return;
+                 if ($reflectionParameter && $reflectionParameter->getType() == null) {
++                    return;
++                }
                 
                 if ($reflectionParameter) {
                     $schema = SchemaHelpers::guessFromReflectionType($reflectionParameter->getType());

--- a/src/Builders/Paths/Operation/ParametersBuilder.php
+++ b/src/Builders/Paths/Operation/ParametersBuilder.php
@@ -34,13 +34,13 @@ class ParametersBuilder
                     ->first(static function (ReflectionParameter $reflectionParameter) use ($parameter) {
                         return $reflectionParameter->name === $parameter['name'];
                     });
-
-                // The reflected param has no type, so ignore (should be defined in a ParametersFactory instead)
-                 if ($reflectionParameter && $reflectionParameter->getType() == null) {
-+                    return null;
-+                }
-                
+ 
                 if ($reflectionParameter) {
+                    // The reflected param has no type, so ignore (should be defined in a ParametersFactory instead)    
+                    if($reflectionParameter->getType() == null) {
+                        return null;
+                    }
+                    
                     $schema = SchemaHelpers::guessFromReflectionType($reflectionParameter->getType());
                 }
 

--- a/src/Builders/Paths/Operation/ParametersBuilder.php
+++ b/src/Builders/Paths/Operation/ParametersBuilder.php
@@ -37,7 +37,7 @@ class ParametersBuilder
 
                 // The reflected param has no type, so ignore (should be defined in a ParametersFactory instead)
                  if ($reflectionParameter && $reflectionParameter->getType() == null) {
-+                    return;
++                    return null;
 +                }
                 
                 if ($reflectionParameter) {

--- a/src/Builders/Paths/Operation/ParametersBuilder.php
+++ b/src/Builders/Paths/Operation/ParametersBuilder.php
@@ -36,11 +36,10 @@ class ParametersBuilder
                     });
  
                 if ($reflectionParameter) {
-                    // The reflected param has no type, so ignore (should be defined in a ParametersFactory instead)    
-                    if($reflectionParameter->getType() == null) {
+                    // The reflected param has no type, so ignore (should be defined in a ParametersFactory instead)
+                    if ($reflectionParameter->getType() == null) {
                         return null;
                     }
-                    
                     $schema = SchemaHelpers::guessFromReflectionType($reflectionParameter->getType());
                 }
 

--- a/src/Builders/Paths/Operation/ParametersBuilder.php
+++ b/src/Builders/Paths/Operation/ParametersBuilder.php
@@ -35,6 +35,9 @@ class ParametersBuilder
                         return $reflectionParameter->name === $parameter['name'];
                     });
 
+                // The reflected param has no type, so ignore (should be defined in a ParametersFactory instead)
+                if($reflectionParameter && $reflectionParameter->getType() == null) return;
+                
                 if ($reflectionParameter) {
                     $schema = SchemaHelpers::guessFromReflectionType($reflectionParameter->getType());
                 }
@@ -49,7 +52,8 @@ class ParametersBuilder
                     ->required()
                     ->description(optional(optional($description)->getDescription())->render())
                     ->schema($schema);
-            });
+            })
+            ->filter();
     }
 
     protected function buildAnnotation(RouteInformation $route): Collection


### PR DESCRIPTION
I wanted to be able to define my route parameter in a ParametersFactory, (I specifically needed to defined enum values for the parameter).
By not typehinting the parameter it gets ignored in `buildPath`, allowing `buildAnnotation` to provide the definition.