### PR TITLE
Add interfaces and custom data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+#!make
+
+.PHONY: tests
+
+COMPOSE_IMAGE = composer:2
+PHP_IMAGE=php:8
+
+composer:
+	docker pull $(DOCKER_COMPOSE)
+	docker run --rm --interactive --tty --user $(id -u):$(id -g) -w /app --volume `pwd`:/app $(COMPOSE_IMAGE) composer $(P)
+
+composer_install:
+	make composer P="install"
+
+phpunit:
+	docker pull $(PHP_IMAGE)
+	docker run --rm -it --user $(id -u):$(id -g) -w /app --volume `pwd`:/app $(PHP_IMAGE) ./vendor/bin/phpunit $(P)
+
+# run all php unit tests
+tests:
+	make phpunit P=tests

--- a/examples/petstore/OpenApi/Parameters/ListPetsParameters.php
+++ b/examples/petstore/OpenApi/Parameters/ListPetsParameters.php
@@ -17,7 +17,7 @@ class ListPetsParameters extends ParametersFactory
 
             Parameter::query()
                 ->name('limit')
-                ->description('How many items to return at one time (max 100)')
+                ->description('How many items to return at one time (max 100) ' . $this->data)
                 ->required(false)
                 ->schema(
                     Schema::integer()->format(Schema::FORMAT_INT32)

--- a/examples/petstore/OpenApi/RequestBodies/CreatePetRequestBody.php
+++ b/examples/petstore/OpenApi/RequestBodies/CreatePetRequestBody.php
@@ -18,7 +18,7 @@ class CreatePetRequestBody implements RequestBodyFactoryInterface
     public function build(): RequestBody
     {
         return RequestBody::create('UserCreate')
-            ->description('Pet data')
+            ->description($this->data['custom'])
             ->content(
                 MediaType::json()->schema(PetSchema::ref())
             );

--- a/examples/petstore/OpenApi/RequestBodies/CreatePetRequestBody.php
+++ b/examples/petstore/OpenApi/RequestBodies/CreatePetRequestBody.php
@@ -1,0 +1,27 @@
+<?php
+
+
+namespace Examples\Petstore\OpenApi\RequestBodies;
+
+
+use Examples\Petstore\OpenApi\Schemas\PetSchema;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\MediaType;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\RequestBody;
+use Vyuldashev\LaravelOpenApi\Concerns\Referencable;
+use Vyuldashev\LaravelOpenApi\Contracts\RequestBodyFactoryInterface;
+
+class CreatePetRequestBody implements RequestBodyFactoryInterface
+{
+
+    use Referencable;
+
+    public function build(): RequestBody
+    {
+        return RequestBody::create('UserCreate')
+            ->description('Pet data')
+            ->content(
+                MediaType::json()->schema(PetSchema::ref())
+            );
+    }
+
+}

--- a/examples/petstore/OpenApi/Responses/ErrorValidationResponse.php
+++ b/examples/petstore/OpenApi/Responses/ErrorValidationResponse.php
@@ -13,7 +13,7 @@ class ErrorValidationResponse extends ResponseFactory implements Reusable
     public function build(): Response
     {
         $response = Schema::object()->properties(
-            Schema::string('message')->example('The given data was invalid.'),
+            Schema::string('message')->example('The given data was invalid. ' . $this->data),
             Schema::object('errors')
                 ->additionalProperties(
                     Schema::array()->items(Schema::string())

--- a/examples/petstore/PetController.php
+++ b/examples/petstore/PetController.php
@@ -3,6 +3,7 @@
 namespace Examples\Petstore;
 
 use Examples\Petstore\OpenApi\Parameters\ListPetsParameters;
+use Examples\Petstore\OpenApi\RequestBodies\CreatePetRequestBody;
 use Examples\Petstore\OpenApi\Responses\ErrorValidationResponse;
 use Vyuldashev\LaravelOpenApi\Attributes as OpenApi;
 
@@ -16,6 +17,15 @@ class PetController
     #[OpenApi\Parameters(ListPetsParameters::class)]
     #[OpenApi\Response(ErrorValidationResponse::class, 422)]
     public function index()
+    {
+    }
+
+    /**
+     * Create pet.
+     */
+    #[OpenApi\Operation('createPet')]
+    #[OpenApi\RequestBody(CreatePetRequestBody::class)]
+    public function create()
     {
     }
 }

--- a/examples/petstore/PetController.php
+++ b/examples/petstore/PetController.php
@@ -14,8 +14,8 @@ class PetController
      * List all pets.
      */
     #[OpenApi\Operation('listPets')]
-    #[OpenApi\Parameters(ListPetsParameters::class)]
-    #[OpenApi\Response(ErrorValidationResponse::class, 422)]
+    #[OpenApi\Parameters(ListPetsParameters::class, "Parameters custom data")]
+    #[OpenApi\Response(ErrorValidationResponse::class, 422, "", "Response custom data")]
     public function index()
     {
     }
@@ -24,7 +24,7 @@ class PetController
      * Create pet.
      */
     #[OpenApi\Operation('createPet')]
-    #[OpenApi\RequestBody(CreatePetRequestBody::class)]
+    #[OpenApi\RequestBody(CreatePetRequestBody::class, ["custom" => "My custom data"])]
     public function create()
     {
     }

--- a/src/Attributes/Callback.php
+++ b/src/Attributes/Callback.php
@@ -4,7 +4,7 @@ namespace Vyuldashev\LaravelOpenApi\Attributes;
 
 use Attribute;
 use InvalidArgumentException;
-use Vyuldashev\LaravelOpenApi\Factories\CallbackFactory;
+use Vyuldashev\LaravelOpenApi\Contracts\CallbackFactoryInterface;
 
 #[Attribute]
 class Callback
@@ -13,10 +13,10 @@ class Callback
 
     public function __construct(string $factory)
     {
-        $this->factory = class_exists($factory) ? $factory : app()->getNamespace().'OpenApi\\Callbacks\\'.$factory;
+        $this->factory = class_exists($factory) ? $factory : app()->getNamespace() . 'OpenApi\\Callbacks\\' . $factory;
 
-        if (! is_a($this->factory, CallbackFactory::class, true)) {
-            throw new InvalidArgumentException('Factory class must be instance of CallbackFactory');
+        if (!is_a($this->factory, CallbackFactoryInterface::class, true)) {
+            throw new InvalidArgumentException('Factory class must be instance of CallbackFactoryInterface');
         }
     }
 }

--- a/src/Attributes/Extension.php
+++ b/src/Attributes/Extension.php
@@ -4,7 +4,7 @@ namespace Vyuldashev\LaravelOpenApi\Attributes;
 
 use Attribute;
 use InvalidArgumentException;
-use Vyuldashev\LaravelOpenApi\Factories\ExtensionFactory;
+use Vyuldashev\LaravelOpenApi\Contracts\ExtensionFactoryInterface;
 
 #[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_METHOD)]
 class Extension
@@ -16,10 +16,10 @@ class Extension
     public function __construct(string $factory = null, string $key = null, string $value = null)
     {
         if ($factory) {
-            $this->factory = class_exists($factory) ? $factory : app()->getNamespace().'OpenApi\\Extensions\\'.$factory;
+            $this->factory = class_exists($factory) ? $factory : app()->getNamespace() . 'OpenApi\\Extensions\\' . $factory;
 
-            if (! is_a($this->factory, ExtensionFactory::class, true)) {
-                throw new InvalidArgumentException('Factory class must be instance of ExtensionFactory');
+            if (!is_a($this->factory, ExtensionFactoryInterface::class, true)) {
+                throw new InvalidArgumentException('Factory class must be instance of ExtensionFactoryInterface');
             }
         }
 

--- a/src/Attributes/Parameters.php
+++ b/src/Attributes/Parameters.php
@@ -10,10 +10,12 @@ use Vyuldashev\LaravelOpenApi\Contracts\ParametersFactoryInterface;
 class Parameters
 {
     public string $factory;
+    public $data;
 
-    public function __construct(string $factory)
+    public function __construct(string $factory, $data = null)
     {
         $this->factory = class_exists($factory) ? $factory : app()->getNamespace() . 'OpenApi\\Parameters\\' . $factory;
+        $this->data = $data;
 
         if (!is_a($this->factory, ParametersFactoryInterface::class, true)) {
             throw new InvalidArgumentException('Factory class must be instance of ParametersFactoryInterface');

--- a/src/Attributes/Parameters.php
+++ b/src/Attributes/Parameters.php
@@ -4,7 +4,7 @@ namespace Vyuldashev\LaravelOpenApi\Attributes;
 
 use Attribute;
 use InvalidArgumentException;
-use Vyuldashev\LaravelOpenApi\Factories\ParametersFactory;
+use Vyuldashev\LaravelOpenApi\Contracts\ParametersFactoryInterface;
 
 #[Attribute(Attribute::TARGET_METHOD)]
 class Parameters
@@ -13,10 +13,10 @@ class Parameters
 
     public function __construct(string $factory)
     {
-        $this->factory = class_exists($factory) ? $factory : app()->getNamespace().'OpenApi\\Parameters\\'.$factory;
+        $this->factory = class_exists($factory) ? $factory : app()->getNamespace() . 'OpenApi\\Parameters\\' . $factory;
 
-        if (! is_a($this->factory, ParametersFactory::class, true)) {
-            throw new InvalidArgumentException('Factory class must be instance of ParametersFactory');
+        if (!is_a($this->factory, ParametersFactoryInterface::class, true)) {
+            throw new InvalidArgumentException('Factory class must be instance of ParametersFactoryInterface');
         }
     }
 }

--- a/src/Attributes/RequestBody.php
+++ b/src/Attributes/RequestBody.php
@@ -4,7 +4,7 @@ namespace Vyuldashev\LaravelOpenApi\Attributes;
 
 use Attribute;
 use InvalidArgumentException;
-use Vyuldashev\LaravelOpenApi\Factories\RequestBodyFactory;
+use Vyuldashev\LaravelOpenApi\Contracts\RequestBodyFactoryInterface;
 
 #[Attribute(Attribute::TARGET_METHOD)]
 class RequestBody
@@ -13,10 +13,10 @@ class RequestBody
 
     public function __construct(string $factory)
     {
-        $this->factory = class_exists($factory) ? $factory : app()->getNamespace().'OpenApi\\RequestBodies\\'.$factory;
+        $this->factory = class_exists($factory) ? $factory : app()->getNamespace() . 'OpenApi\\RequestBodies\\' . $factory;
 
-        if (! is_a($this->factory, RequestBodyFactory::class, true)) {
-            throw new InvalidArgumentException('Factory class must be instance of RequestBodyFactory');
+        if (!is_a($this->factory, RequestBodyFactoryInterface::class, true)) {
+            throw new InvalidArgumentException('Factory class must be instance of RequestBodyFactoryInterface');
         }
     }
 }

--- a/src/Attributes/RequestBody.php
+++ b/src/Attributes/RequestBody.php
@@ -10,10 +10,12 @@ use Vyuldashev\LaravelOpenApi\Contracts\RequestBodyFactoryInterface;
 class RequestBody
 {
     public string $factory;
+    public $data;
 
-    public function __construct(string $factory)
+    public function __construct(string $factory, $data = null)
     {
         $this->factory = class_exists($factory) ? $factory : app()->getNamespace() . 'OpenApi\\RequestBodies\\' . $factory;
+        $this->data = $data;
 
         if (!is_a($this->factory, RequestBodyFactoryInterface::class, true)) {
             throw new InvalidArgumentException('Factory class must be instance of RequestBodyFactoryInterface');

--- a/src/Attributes/Response.php
+++ b/src/Attributes/Response.php
@@ -4,7 +4,7 @@ namespace Vyuldashev\LaravelOpenApi\Attributes;
 
 use Attribute;
 use InvalidArgumentException;
-use Vyuldashev\LaravelOpenApi\Factories\ResponseFactory;
+use Vyuldashev\LaravelOpenApi\Contracts\ResponseFactoryInterface;
 
 #[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 class Response
@@ -17,10 +17,10 @@ class Response
 
     public function __construct(string $factory, int $statusCode = null, string $description = null)
     {
-        $this->factory = class_exists($factory) ? $factory : app()->getNamespace().'OpenApi\\Responses\\'.$factory;
+        $this->factory = class_exists($factory) ? $factory : app()->getNamespace() . 'OpenApi\\Responses\\' . $factory;
 
-        if (! is_a($this->factory, ResponseFactory::class, true)) {
-            throw new InvalidArgumentException('Factory class must be instance of ResponseFactory');
+        if (!is_a($this->factory, ResponseFactoryInterface::class, true)) {
+            throw new InvalidArgumentException('Factory class must be instance of ResponseFactoryInterface');
         }
 
         $this->statusCode = $statusCode;

--- a/src/Attributes/Response.php
+++ b/src/Attributes/Response.php
@@ -15,9 +15,12 @@ class Response
 
     public ?string $description;
 
-    public function __construct(string $factory, int $statusCode = null, string $description = null)
+    public $data;
+
+    public function __construct(string $factory, int $statusCode = null, string $description = null, $data = null)
     {
         $this->factory = class_exists($factory) ? $factory : app()->getNamespace() . 'OpenApi\\Responses\\' . $factory;
+        $this->data = $data;
 
         if (!is_a($this->factory, ResponseFactoryInterface::class, true)) {
             throw new InvalidArgumentException('Factory class must be instance of ResponseFactoryInterface');

--- a/src/Builders/Components/CallbacksBuilder.php
+++ b/src/Builders/Components/CallbacksBuilder.php
@@ -2,8 +2,8 @@
 
 namespace Vyuldashev\LaravelOpenApi\Builders\Components;
 
+use Vyuldashev\LaravelOpenApi\Contracts\CallbackFactoryInterface;
 use Vyuldashev\LaravelOpenApi\Contracts\Reusable;
-use Vyuldashev\LaravelOpenApi\Factories\CallbackFactory;
 use Vyuldashev\LaravelOpenApi\Generator;
 
 class CallbacksBuilder extends Builder
@@ -13,11 +13,11 @@ class CallbacksBuilder extends Builder
         return $this->getAllClasses($collection)
             ->filter(static function ($class) {
                 return
-                    is_a($class, CallbackFactory::class, true) &&
+                    is_a($class, CallbackFactoryInterface::class, true) &&
                     is_a($class, Reusable::class, true);
             })
             ->map(static function ($class) {
-                /** @var CallbackFactory $instance */
+                /** @var CallbackFactoryInterface $instance */
                 $instance = app($class);
 
                 return $instance->build();

--- a/src/Builders/Components/RequestBodiesBuilder.php
+++ b/src/Builders/Components/RequestBodiesBuilder.php
@@ -2,8 +2,8 @@
 
 namespace Vyuldashev\LaravelOpenApi\Builders\Components;
 
+use Vyuldashev\LaravelOpenApi\Contracts\RequestBodyFactoryInterface;
 use Vyuldashev\LaravelOpenApi\Contracts\Reusable;
-use Vyuldashev\LaravelOpenApi\Factories\RequestBodyFactory;
 use Vyuldashev\LaravelOpenApi\Generator;
 
 class RequestBodiesBuilder extends Builder
@@ -13,11 +13,11 @@ class RequestBodiesBuilder extends Builder
         return $this->getAllClasses($collection)
             ->filter(static function ($class) {
                 return
-                    is_a($class, RequestBodyFactory::class, true) &&
+                    is_a($class, RequestBodyFactoryInterface::class, true) &&
                     is_a($class, Reusable::class, true);
             })
             ->map(static function ($class) {
-                /** @var RequestBodyFactory $instance */
+                /** @var RequestBodyFactoryInterface $instance */
                 $instance = app($class);
 
                 return $instance->build();

--- a/src/Builders/Components/ResponsesBuilder.php
+++ b/src/Builders/Components/ResponsesBuilder.php
@@ -2,8 +2,8 @@
 
 namespace Vyuldashev\LaravelOpenApi\Builders\Components;
 
+use Vyuldashev\LaravelOpenApi\Contracts\ResponseFactoryInterface;
 use Vyuldashev\LaravelOpenApi\Contracts\Reusable;
-use Vyuldashev\LaravelOpenApi\Factories\ResponseFactory;
 use Vyuldashev\LaravelOpenApi\Generator;
 
 class ResponsesBuilder extends Builder
@@ -13,11 +13,11 @@ class ResponsesBuilder extends Builder
         return $this->getAllClasses($collection)
             ->filter(static function ($class) {
                 return
-                    is_a($class, ResponseFactory::class, true) &&
+                    is_a($class, ResponseFactoryInterface::class, true) &&
                     is_a($class, Reusable::class, true);
             })
             ->map(static function ($class) {
-                /** @var ResponseFactory $instance */
+                /** @var ResponseFactoryInterface $instance */
                 $instance = app($class);
 
                 return $instance->build();

--- a/src/Builders/Components/SchemasBuilder.php
+++ b/src/Builders/Components/SchemasBuilder.php
@@ -3,7 +3,7 @@
 namespace Vyuldashev\LaravelOpenApi\Builders\Components;
 
 use Vyuldashev\LaravelOpenApi\Contracts\Reusable;
-use Vyuldashev\LaravelOpenApi\Factories\SchemaFactory;
+use Vyuldashev\LaravelOpenApi\Contracts\SchemaFactoryInterface;
 use Vyuldashev\LaravelOpenApi\Generator;
 
 class SchemasBuilder extends Builder
@@ -13,11 +13,11 @@ class SchemasBuilder extends Builder
         return $this->getAllClasses($collection)
             ->filter(static function ($class) {
                 return
-                    is_a($class, SchemaFactory::class, true) &&
+                    is_a($class, SchemaFactoryInterface::class, true) &&
                     is_a($class, Reusable::class, true);
             })
             ->map(static function ($class) {
-                /** @var SchemaFactory $instance */
+                /** @var SchemaFactoryInterface $instance */
                 $instance = app($class);
 
                 return $instance->build();

--- a/src/Builders/Components/SecuritySchemesBuilder.php
+++ b/src/Builders/Components/SecuritySchemesBuilder.php
@@ -2,7 +2,7 @@
 
 namespace Vyuldashev\LaravelOpenApi\Builders\Components;
 
-use Vyuldashev\LaravelOpenApi\Factories\SecuritySchemeFactory;
+use Vyuldashev\LaravelOpenApi\Contracts\SecuritySchemeFactoryInterface;
 use Vyuldashev\LaravelOpenApi\Generator;
 
 class SecuritySchemesBuilder extends Builder
@@ -11,10 +11,10 @@ class SecuritySchemesBuilder extends Builder
     {
         return $this->getAllClasses($collection)
             ->filter(static function ($class) {
-                return is_a($class, SecuritySchemeFactory::class, true);
+                return is_a($class, SecuritySchemeFactoryInterface::class, true);
             })
             ->map(static function ($class) {
-                /** @var SecuritySchemeFactory $instance */
+                /** @var SecuritySchemeFactoryInterface $instance */
                 $instance = app($class);
 
                 return $instance->build();

--- a/src/Builders/ExtensionsBuilder.php
+++ b/src/Builders/ExtensionsBuilder.php
@@ -5,7 +5,7 @@ namespace Vyuldashev\LaravelOpenApi\Builders;
 use GoldSpecDigital\ObjectOrientedOAS\Objects\BaseObject;
 use Illuminate\Support\Collection;
 use Vyuldashev\LaravelOpenApi\Attributes\Extension as ExtensionAttribute;
-use Vyuldashev\LaravelOpenApi\Factories\ExtensionFactory;
+use Vyuldashev\LaravelOpenApi\Contracts\ExtensionFactoryInterface;
 
 class ExtensionsBuilder
 {
@@ -15,7 +15,7 @@ class ExtensionsBuilder
             ->filter(static fn(object $attribute) => $attribute instanceof ExtensionAttribute)
             ->each(static function (ExtensionAttribute $attribute) use ($object): void {
                 if ($attribute->factory) {
-                    /** @var ExtensionFactory $factory */
+                    /** @var ExtensionFactoryInterface $factory */
                     $factory = app($attribute->factory);
                     $key = $factory->key();
                     $value = $factory->value();

--- a/src/Builders/Paths/Operation/ParametersBuilder.php
+++ b/src/Builders/Paths/Operation/ParametersBuilder.php
@@ -62,7 +62,8 @@ class ParametersBuilder
         if ($parameters) {
             /** @var ParametersFactoryInterface $parametersFactory */
             $parametersFactory = app($parameters->factory);
-
+            // little bit magic, add custom data into factory
+            $parametersFactory->data = $parameters->data;
             $parameters = $parametersFactory->build();
         }
 

--- a/src/Builders/Paths/Operation/ParametersBuilder.php
+++ b/src/Builders/Paths/Operation/ParametersBuilder.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Str;
 use phpDocumentor\Reflection\DocBlock\Tags\Param;
 use ReflectionParameter;
 use Vyuldashev\LaravelOpenApi\Attributes\Parameters;
-use Vyuldashev\LaravelOpenApi\Factories\ParametersFactory;
+use Vyuldashev\LaravelOpenApi\Contracts\ParametersFactoryInterface;
 use Vyuldashev\LaravelOpenApi\RouteInformation;
 use Vyuldashev\LaravelOpenApi\SchemaHelpers;
 
@@ -60,7 +60,7 @@ class ParametersBuilder
         $parameters = $route->actionAttributes->first(static fn($attribute) => $attribute instanceof Parameters, []);
 
         if ($parameters) {
-            /** @var ParametersFactory $parametersFactory */
+            /** @var ParametersFactoryInterface $parametersFactory */
             $parametersFactory = app($parameters->factory);
 
             $parameters = $parametersFactory->build();

--- a/src/Builders/Paths/Operation/RequestBodyBuilder.php
+++ b/src/Builders/Paths/Operation/RequestBodyBuilder.php
@@ -18,7 +18,8 @@ class RequestBodyBuilder
         if ($requestBody) {
             /** @var RequestBodyFactoryInterface $requestBodyFactory */
             $requestBodyFactory = app($requestBody->factory);
-
+            // little bit magic, add custom data into factory
+            $requestBodyFactory->data = $requestBody->data;
             $requestBody = $requestBodyFactory->build();
 
             if ($requestBodyFactory instanceof Reusable) {

--- a/src/Builders/Paths/Operation/RequestBodyBuilder.php
+++ b/src/Builders/Paths/Operation/RequestBodyBuilder.php
@@ -4,8 +4,8 @@ namespace Vyuldashev\LaravelOpenApi\Builders\Paths\Operation;
 
 use GoldSpecDigital\ObjectOrientedOAS\Objects\RequestBody;
 use Vyuldashev\LaravelOpenApi\Attributes\RequestBody as RequestBodyAttribute;
+use Vyuldashev\LaravelOpenApi\Contracts\RequestBodyFactoryInterface;
 use Vyuldashev\LaravelOpenApi\Contracts\Reusable;
-use Vyuldashev\LaravelOpenApi\Factories\RequestBodyFactory;
 use Vyuldashev\LaravelOpenApi\RouteInformation;
 
 class RequestBodyBuilder
@@ -16,13 +16,13 @@ class RequestBodyBuilder
         $requestBody = $route->actionAttributes->first(static fn(object $attribute) => $attribute instanceof RequestBodyAttribute);
 
         if ($requestBody) {
-            /** @var RequestBodyFactory $requestBodyFactory */
+            /** @var RequestBodyFactoryInterface $requestBodyFactory */
             $requestBodyFactory = app($requestBody->factory);
 
             $requestBody = $requestBodyFactory->build();
 
             if ($requestBodyFactory instanceof Reusable) {
-                return RequestBody::ref('#/components/requestBodies/'.$requestBody->objectId);
+                return RequestBody::ref('#/components/requestBodies/' . $requestBody->objectId);
             }
         }
 

--- a/src/Builders/Paths/Operation/ResponsesBuilder.php
+++ b/src/Builders/Paths/Operation/ResponsesBuilder.php
@@ -15,10 +15,12 @@ class ResponsesBuilder
             ->filter(static fn(object $attribute) => $attribute instanceof ResponseAttribute)
             ->map(static function (ResponseAttribute $attribute) {
                 $factory = app($attribute->factory);
+                // little bit magic, add custom data into factory
+                $factory->data = $attribute->data;
                 $response = $factory->build();
 
                 if ($factory instanceof Reusable) {
-                    return Response::ref('#/components/responses/'.$response->objectId)
+                    return Response::ref('#/components/responses/' . $response->objectId)
                         ->statusCode($attribute->statusCode)
                         ->description($attribute->description);
                 }

--- a/src/Concerns/Referencable.php
+++ b/src/Concerns/Referencable.php
@@ -4,13 +4,13 @@ namespace Vyuldashev\LaravelOpenApi\Concerns;
 
 use GoldSpecDigital\ObjectOrientedOAS\Objects\Schema;
 use InvalidArgumentException;
+use Vyuldashev\LaravelOpenApi\Contracts\CallbackFactoryInterface;
+use Vyuldashev\LaravelOpenApi\Contracts\ParametersFactoryInterface;
+use Vyuldashev\LaravelOpenApi\Contracts\RequestBodyFactoryInterface;
+use Vyuldashev\LaravelOpenApi\Contracts\ResponseFactoryInterface;
 use Vyuldashev\LaravelOpenApi\Contracts\Reusable;
-use Vyuldashev\LaravelOpenApi\Factories\CallbackFactory;
-use Vyuldashev\LaravelOpenApi\Factories\ParametersFactory;
-use Vyuldashev\LaravelOpenApi\Factories\RequestBodyFactory;
-use Vyuldashev\LaravelOpenApi\Factories\ResponseFactory;
-use Vyuldashev\LaravelOpenApi\Factories\SchemaFactory;
-use Vyuldashev\LaravelOpenApi\Factories\SecuritySchemeFactory;
+use Vyuldashev\LaravelOpenApi\Contracts\SchemaFactoryInterface;
+use Vyuldashev\LaravelOpenApi\Contracts\SecuritySchemeFactoryInterface;
 
 trait Referencable
 {
@@ -18,26 +18,26 @@ trait Referencable
     {
         $instance = app(static::class);
 
-        if (! $instance instanceof Reusable) {
-            throw new InvalidArgumentException('"'.static::class.'" must implement "'.Reusable::class.'" in order to be referencable.');
+        if (!$instance instanceof Reusable) {
+            throw new InvalidArgumentException('"' . static::class . '" must implement "' . Reusable::class . '" in order to be referencable.');
         }
 
         $baseRef = null;
 
-        if ($instance instanceof CallbackFactory) {
+        if ($instance instanceof CallbackFactoryInterface) {
             $baseRef = '#/components/callbacks/';
-        } elseif ($instance instanceof ParametersFactory) {
+        } elseif ($instance instanceof ParametersFactoryInterface) {
             $baseRef = '#/components/parameters/';
-        } elseif ($instance instanceof RequestBodyFactory) {
+        } elseif ($instance instanceof RequestBodyFactoryInterface) {
             $baseRef = '#/components/requestBodies/';
-        } elseif ($instance instanceof ResponseFactory) {
+        } elseif ($instance instanceof ResponseFactoryInterface) {
             $baseRef = '#/components/responses/';
-        } elseif ($instance instanceof SchemaFactory) {
+        } elseif ($instance instanceof SchemaFactoryInterface) {
             $baseRef = '#/components/schemas/';
-        } elseif ($instance instanceof SecuritySchemeFactory) {
+        } elseif ($instance instanceof SecuritySchemeFactoryInterface) {
             $baseRef = '#/components/securitySchemes/';
         }
 
-        return Schema::ref($baseRef.$instance->build()->objectId, $objectId);
+        return Schema::ref($baseRef . $instance->build()->objectId, $objectId);
     }
 }

--- a/src/Contracts/CallbackFactoryInterface.php
+++ b/src/Contracts/CallbackFactoryInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+
+namespace Vyuldashev\LaravelOpenApi\Contracts;
+
+
+use GoldSpecDigital\ObjectOrientedOAS\Objects\PathItem;
+
+interface CallbackFactoryInterface
+{
+    public function build(): PathItem;
+}

--- a/src/Contracts/ExtensionFactoryInterface.php
+++ b/src/Contracts/ExtensionFactoryInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+
+namespace Vyuldashev\LaravelOpenApi\Contracts;
+
+
+interface ExtensionFactoryInterface
+{
+    public function key(): string;
+
+    /**
+     * @return string|null|array
+     */
+    public function value();
+}

--- a/src/Contracts/ParametersFactoryInterface.php
+++ b/src/Contracts/ParametersFactoryInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+
+namespace Vyuldashev\LaravelOpenApi\Contracts;
+
+
+use GoldSpecDigital\ObjectOrientedOAS\Objects\Parameter;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\Schema;
+
+interface ParametersFactoryInterface
+{
+    /**
+     * @return Parameter[]
+     */
+    public function build(): array;
+
+    public static function ref(?string $objectId = null): Schema;
+}

--- a/src/Contracts/RequestBodyFactoryInterface.php
+++ b/src/Contracts/RequestBodyFactoryInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+
+namespace Vyuldashev\LaravelOpenApi\Contracts;
+
+
+use GoldSpecDigital\ObjectOrientedOAS\Objects\RequestBody;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\Schema;
+
+/**
+ * Interface RequestBodyFactoryInterface
+ * @package Vyuldashev\LaravelOpenApi\Contracts
+ * @var $data
+ */
+interface RequestBodyFactoryInterface
+{
+    public function build(): RequestBody;
+
+    public static function ref(?string $objectId = null): Schema;
+}

--- a/src/Contracts/ResponseFactoryInterface.php
+++ b/src/Contracts/ResponseFactoryInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+
+namespace Vyuldashev\LaravelOpenApi\Contracts;
+
+
+use GoldSpecDigital\ObjectOrientedOAS\Objects\Response;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\Schema;
+
+interface ResponseFactoryInterface
+{
+    public function build(): Response;
+
+    public static function ref(?string $objectId = null): Schema;
+}

--- a/src/Contracts/SchemaFactoryInterface.php
+++ b/src/Contracts/SchemaFactoryInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+
+namespace Vyuldashev\LaravelOpenApi\Contracts;
+
+
+use GoldSpecDigital\ObjectOrientedOAS\Contracts\SchemaContract;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\AllOf;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\AnyOf;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\Not;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\OneOf;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\Schema;
+
+interface SchemaFactoryInterface
+{
+    /**
+     * @return AllOf|OneOf|AnyOf|Not|Schema
+     */
+    public function build(): SchemaContract;
+
+    public static function ref(?string $objectId = null): Schema;
+}

--- a/src/Contracts/SecuritySchemeFactoryInterface.php
+++ b/src/Contracts/SecuritySchemeFactoryInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+
+namespace Vyuldashev\LaravelOpenApi\Contracts;
+
+
+use GoldSpecDigital\ObjectOrientedOAS\Objects\SecurityScheme;
+
+interface SecuritySchemeFactoryInterface
+{
+    public function build(): SecurityScheme;
+}

--- a/src/Factories/CallbackFactory.php
+++ b/src/Factories/CallbackFactory.php
@@ -2,9 +2,8 @@
 
 namespace Vyuldashev\LaravelOpenApi\Factories;
 
-use GoldSpecDigital\ObjectOrientedOAS\Objects\PathItem;
+use Vyuldashev\LaravelOpenApi\Contracts\CallbackFactoryInterface;
 
-abstract class CallbackFactory
+abstract class CallbackFactory implements CallbackFactoryInterface
 {
-    abstract public function build(): PathItem;
 }

--- a/src/Factories/ExtensionFactory.php
+++ b/src/Factories/ExtensionFactory.php
@@ -2,12 +2,8 @@
 
 namespace Vyuldashev\LaravelOpenApi\Factories;
 
-abstract class ExtensionFactory
-{
-    abstract public function key(): string;
+use Vyuldashev\LaravelOpenApi\Contracts\ExtensionFactoryInterface;
 
-    /**
-     * @return string|null|array
-     */
-    abstract public function value();
+abstract class ExtensionFactory implements ExtensionFactoryInterface
+{
 }

--- a/src/Factories/ParametersFactory.php
+++ b/src/Factories/ParametersFactory.php
@@ -2,15 +2,10 @@
 
 namespace Vyuldashev\LaravelOpenApi\Factories;
 
-use GoldSpecDigital\ObjectOrientedOAS\Objects\Parameter;
 use Vyuldashev\LaravelOpenApi\Concerns\Referencable;
+use Vyuldashev\LaravelOpenApi\Contracts\ParametersFactoryInterface;
 
-abstract class ParametersFactory
+abstract class ParametersFactory implements ParametersFactoryInterface
 {
     use Referencable;
-
-    /**
-     * @return Parameter[]
-     */
-    abstract public function build(): array;
 }

--- a/src/Factories/RequestBodyFactory.php
+++ b/src/Factories/RequestBodyFactory.php
@@ -2,12 +2,10 @@
 
 namespace Vyuldashev\LaravelOpenApi\Factories;
 
-use GoldSpecDigital\ObjectOrientedOAS\Objects\RequestBody;
 use Vyuldashev\LaravelOpenApi\Concerns\Referencable;
+use Vyuldashev\LaravelOpenApi\Contracts\RequestBodyFactoryInterface;
 
-abstract class RequestBodyFactory
+abstract class RequestBodyFactory implements RequestBodyFactoryInterface
 {
     use Referencable;
-
-    abstract public function build(): RequestBody;
 }

--- a/src/Factories/ResponseFactory.php
+++ b/src/Factories/ResponseFactory.php
@@ -2,12 +2,10 @@
 
 namespace Vyuldashev\LaravelOpenApi\Factories;
 
-use GoldSpecDigital\ObjectOrientedOAS\Objects\Response;
 use Vyuldashev\LaravelOpenApi\Concerns\Referencable;
+use Vyuldashev\LaravelOpenApi\Contracts\ResponseFactoryInterface;
 
-abstract class ResponseFactory
+abstract class ResponseFactory implements ResponseFactoryInterface
 {
     use Referencable;
-
-    abstract public function build(): Response;
 }

--- a/src/Factories/SchemaFactory.php
+++ b/src/Factories/SchemaFactory.php
@@ -2,20 +2,10 @@
 
 namespace Vyuldashev\LaravelOpenApi\Factories;
 
-use GoldSpecDigital\ObjectOrientedOAS\Contracts\SchemaContract;
-use GoldSpecDigital\ObjectOrientedOAS\Objects\AllOf;
-use GoldSpecDigital\ObjectOrientedOAS\Objects\AnyOf;
-use GoldSpecDigital\ObjectOrientedOAS\Objects\Not;
-use GoldSpecDigital\ObjectOrientedOAS\Objects\OneOf;
-use GoldSpecDigital\ObjectOrientedOAS\Objects\Schema;
 use Vyuldashev\LaravelOpenApi\Concerns\Referencable;
+use Vyuldashev\LaravelOpenApi\Contracts\SchemaFactoryInterface;
 
-abstract class SchemaFactory
+abstract class SchemaFactory implements SchemaFactoryInterface
 {
     use Referencable;
-
-    /**
-     * @return AllOf|OneOf|AnyOf|Not|Schema
-     */
-    abstract public function build(): SchemaContract;
 }

--- a/src/Factories/SecuritySchemeFactory.php
+++ b/src/Factories/SecuritySchemeFactory.php
@@ -3,8 +3,9 @@
 namespace Vyuldashev\LaravelOpenApi\Factories;
 
 use GoldSpecDigital\ObjectOrientedOAS\Objects\SecurityScheme;
+use Vyuldashev\LaravelOpenApi\Contracts\SecuritySchemeFactoryInterface;
 
-abstract class SecuritySchemeFactory
+abstract class SecuritySchemeFactory implements SecuritySchemeFactoryInterface
 {
     abstract public function build(): SecurityScheme;
 }

--- a/tests/PetstoreTest.php
+++ b/tests/PetstoreTest.php
@@ -43,7 +43,7 @@ class PetstoreTest extends TestCase
                 [
                     'name' => 'limit',
                     'in' => 'query',
-                    'description' => 'How many items to return at one time (max 100)',
+                    'description' => 'How many items to return at one time (max 100) Parameters custom data',
                     'required' => false,
                     'schema' => [
                         'format' => 'int32',
@@ -86,7 +86,7 @@ class PetstoreTest extends TestCase
             'summary' => 'Create pet.',
             'operationId' => 'createPet',
             'requestBody' => [
-                "description" => "Pet data",
+                "description" => "My custom data",
                 "content" => [
                     "application/json" => [
                         "schema" => [

--- a/tests/PetstoreTest.php
+++ b/tests/PetstoreTest.php
@@ -17,12 +17,13 @@ class PetstoreTest extends TestCase
         parent::setUp();
 
         Route::get('/pets', [PetController::class, 'index']);
+        Route::post('/pet', [PetController::class, 'create']);
     }
 
     protected function getEnvironmentSetUp($app): void
     {
         $app['config']->set('openapi.locations.schemas', [
-            __DIR__.'/../examples/petstore/OpenApi/Schemas',
+            __DIR__ . '/../examples/petstore/OpenApi/Schemas',
         ]);
     }
 
@@ -80,5 +81,20 @@ class PetstoreTest extends TestCase
                 ],
             ],
         ], $spec['components']['schemas']['Pet']);
+
+        self::assertEquals([
+            'summary' => 'Create pet.',
+            'operationId' => 'createPet',
+            'requestBody' => [
+                "description" => "Pet data",
+                "content" => [
+                    "application/json" => [
+                        "schema" => [
+                            '$ref' => "#/components/schemas/Pet",
+                        ]
+                    ],
+                ],
+            ],
+        ], $spec['paths']['/pet']['post']);
     }
 }


### PR DESCRIPTION
With interfaces and custom data users can make their own factories.
It is possible to make general factory (for example `MyGeneralParametersFactory`). 
This factory get custom data `["class"=>PetsParameter::class]`. 
Then user's factory can do autogenerating schema depending on `PetsParameter::class` attributes.
User will have only few general factories (Parameter, Response...). Theses factories will get classes with attributes or it could be yaml file with schema definition and will autogenerates 
final schema.