### PR TITLE
Add security to Operations

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -26,6 +26,7 @@ module.exports = {
       '/schemas',
       '/collections',
       '/middlewares',
+      '/security'
     ],
     displayAllHeaders: true,
     sidebarDepth: 2,

--- a/docs/paths/operations.md
+++ b/docs/paths/operations.md
@@ -39,6 +39,10 @@ The following definition will be generated:
 }
 ```
 
+## Security
+
+See [Security](../security.md#operation-level-example)
+
 ## Tags
 
 Tags can be used for logical grouping of operations by resources or any other qualifier.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,40 @@
+# Security
+
+```bash
+php artisan openapi:make-security-scheme BearerToken
+```
+
+After you generate a security scheme, it will be declared in the `securitySchemes` section, you can apply it to the whole API or individual operations by adding the security section on the root level or operation level, respectively. When used on the root level, security applies the specified security schemes globally to all API operations, unless overridden on the operation level.
+
+## Root level example
+
+`config/openapi.php`:
+
+```php
+
+'security' => [
+  GoldSpecDigital\ObjectOrientedOAS\Objects\SecurityRequirement::create()->securityScheme('BearerToken'),
+],
+
+```
+
+## Operation level example
+
+```php
+use Vyuldashev\LaravelOpenApi\Attributes as OpenApi;
+
+#[OpenApi\PathItem]
+class UserController extends Controller
+{
+    /**
+     * Create new user.
+     *
+     * Creates new user or returns already existing user by email.
+     */
+     #[OpenApi\Operation(security: ['BearerToken'])]
+    public function store(Request $request)
+    {
+        //
+    }
+}
+```

--- a/docs/security.md
+++ b/docs/security.md
@@ -31,7 +31,7 @@ class UserController extends Controller
      *
      * Creates new user or returns already existing user by email.
      */
-     #[OpenApi\Operation(security: ['BearerToken'])]
+     #[OpenApi\Operation(security: 'BearerToken')]
     public function store(Request $request)
     {
         //

--- a/src/Attributes/Operation.php
+++ b/src/Attributes/Operation.php
@@ -32,9 +32,9 @@ class Operation
         $this->method = $method;
 
         if ($security) {
-            $this->security = class_exists($security) ? $security : app()->getNamespace() . 'OpenApi\\SecuritySchemes\\' . $security . 'SecurityScheme';
+            $this->security = class_exists($security) ? $security : app()->getNamespace().'OpenApi\\SecuritySchemes\\'.$security.'SecurityScheme';
 
-            if (!is_a($this->security, SecuritySchemeFactory::class, true)) {
+            if (! is_a($this->security, SecuritySchemeFactory::class, true)) {
                 throw new InvalidArgumentException(
                     sprintf('Security class is either not declared or is not an instance of [%s]', SecuritySchemeFactory::class)
                 );

--- a/src/Attributes/Operation.php
+++ b/src/Attributes/Operation.php
@@ -12,12 +12,16 @@ class Operation
     /** @var array<string> */
     public array $tags;
 
+    /** @var array<string> */
+    public array $security;
+
     public ?string $method;
 
-    public function __construct(string $id = null, array $tags = [], string $method = null)
+    public function __construct(string $id = null, array $tags = [], array $security = [], string $method = null)
     {
         $this->id = $id;
         $this->tags = $tags;
+        $this->security = $security;
         $this->method = $method;
     }
 }

--- a/src/Builders/Paths/Operation/SecurityBuilder.php
+++ b/src/Builders/Paths/Operation/SecurityBuilder.php
@@ -8,18 +8,18 @@ use Vyuldashev\LaravelOpenApi\RouteInformation;
 
 class SecurityBuilder
 {
-  public function build(RouteInformation $route): array
-  {
-    return $route->actionAttributes
-      ->filter(static fn (object $attribute) => $attribute instanceof OperationAttribute)
-      ->filter(static fn (OperationAttribute $attribute) => isset($attribute->security))
-      ->map(static function (OperationAttribute $attribute) {
-        $security = app($attribute->security);
-        $scheme = $security->build();
+    public function build(RouteInformation $route): array
+    {
+        return $route->actionAttributes
+            ->filter(static fn (object $attribute) => $attribute instanceof OperationAttribute)
+            ->filter(static fn (OperationAttribute $attribute) => isset($attribute->security))
+            ->map(static function (OperationAttribute $attribute) {
+                $security = app($attribute->security);
+                $scheme = $security->build();
 
-        return SecurityRequirement::create()->securityScheme($scheme);
-      })
-      ->values()
-      ->toArray();
-  }
+                return SecurityRequirement::create()->securityScheme($scheme);
+            })
+            ->values()
+            ->toArray();
+    }
 }

--- a/src/Builders/Paths/Operation/SecurityBuilder.php
+++ b/src/Builders/Paths/Operation/SecurityBuilder.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Vyuldashev\LaravelOpenApi\Builders\Paths\Operation;
+
+use GoldSpecDigital\ObjectOrientedOAS\Objects\SecurityRequirement;
+use Vyuldashev\LaravelOpenApi\Attributes\Operation as OperationAttribute;
+use Vyuldashev\LaravelOpenApi\RouteInformation;
+
+class SecurityBuilder
+{
+  public function build(RouteInformation $route): array
+  {
+    return $route->actionAttributes
+      ->filter(static fn (object $attribute) => $attribute instanceof OperationAttribute)
+      ->filter(static fn (OperationAttribute $attribute) => isset($attribute->security))
+      ->map(static function (OperationAttribute $attribute) {
+        $security = app($attribute->security);
+        $scheme = $security->build();
+
+        return SecurityRequirement::create()->securityScheme($scheme);
+      })
+      ->values()
+      ->toArray();
+  }
+}

--- a/src/Builders/Paths/OperationsBuilder.php
+++ b/src/Builders/Paths/OperationsBuilder.php
@@ -50,11 +50,11 @@ class OperationsBuilder
         foreach ($routes as $route) {
             /** @var OperationAttribute|null $operationAttribute */
             $operationAttribute = $route->actionAttributes
-                ->first(static fn(object $attribute) => $attribute instanceof OperationAttribute);
+                ->first(static fn (object $attribute) => $attribute instanceof OperationAttribute);
 
             $operationId = optional($operationAttribute)->id;
             $tags = $operationAttribute->tags ?? [];
-            $security = array_map(fn($s) => SecurityRequirement::create()->securityScheme($s), $operationAttribute->security);
+            $security = array_map(fn ($s) => SecurityRequirement::create()->securityScheme($s), $operationAttribute->security);
 
             $parameters = $this->parametersBuilder->build($route);
             $requestBody = $this->requestBodyBuilder->build($route);

--- a/src/Builders/Paths/OperationsBuilder.php
+++ b/src/Builders/Paths/OperationsBuilder.php
@@ -4,6 +4,7 @@ namespace Vyuldashev\LaravelOpenApi\Builders\Paths;
 
 use GoldSpecDigital\ObjectOrientedOAS\Exceptions\InvalidArgumentException;
 use GoldSpecDigital\ObjectOrientedOAS\Objects\Operation;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\SecurityRequirement;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Vyuldashev\LaravelOpenApi\Attributes\Operation as OperationAttribute;
@@ -53,6 +54,7 @@ class OperationsBuilder
 
             $operationId = optional($operationAttribute)->id;
             $tags = $operationAttribute->tags ?? [];
+            $security = array_map(fn ($s) => SecurityRequirement::create()->securityScheme($s), $operationAttribute->security);
 
             $parameters = $this->parametersBuilder->build($route);
             $requestBody = $this->requestBodyBuilder->build($route);
@@ -68,7 +70,8 @@ class OperationsBuilder
                 ->parameters(...$parameters)
                 ->requestBody($requestBody)
                 ->responses(...$responses)
-                ->callbacks(...$callbacks);
+                ->callbacks(...$callbacks)
+                ->security(...$security);
 
             $this->extensionsBuilder->build($operation, $route->actionAttributes);
 

--- a/src/Builders/Paths/OperationsBuilder.php
+++ b/src/Builders/Paths/OperationsBuilder.php
@@ -4,18 +4,15 @@ namespace Vyuldashev\LaravelOpenApi\Builders\Paths;
 
 use GoldSpecDigital\ObjectOrientedOAS\Exceptions\InvalidArgumentException;
 use GoldSpecDigital\ObjectOrientedOAS\Objects\Operation;
-use GoldSpecDigital\ObjectOrientedOAS\Objects\SecurityRequirement;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Vyuldashev\LaravelOpenApi\Attributes\Operation as OperationAttribute;
-use Vyuldashev\LaravelOpenApi\Builders\Components\SecuritySchemesBuilder;
 use Vyuldashev\LaravelOpenApi\Builders\ExtensionsBuilder;
 use Vyuldashev\LaravelOpenApi\Builders\Paths\Operation\CallbacksBuilder;
 use Vyuldashev\LaravelOpenApi\Builders\Paths\Operation\ParametersBuilder;
 use Vyuldashev\LaravelOpenApi\Builders\Paths\Operation\RequestBodyBuilder;
 use Vyuldashev\LaravelOpenApi\Builders\Paths\Operation\ResponsesBuilder;
 use Vyuldashev\LaravelOpenApi\Builders\Paths\Operation\SecurityBuilder;
-use Vyuldashev\LaravelOpenApi\Factories\SecuritySchemeFactory;
 use Vyuldashev\LaravelOpenApi\RouteInformation;
 
 class OperationsBuilder

--- a/src/Builders/Paths/OperationsBuilder.php
+++ b/src/Builders/Paths/OperationsBuilder.php
@@ -8,11 +8,14 @@ use GoldSpecDigital\ObjectOrientedOAS\Objects\SecurityRequirement;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Vyuldashev\LaravelOpenApi\Attributes\Operation as OperationAttribute;
+use Vyuldashev\LaravelOpenApi\Builders\Components\SecuritySchemesBuilder;
 use Vyuldashev\LaravelOpenApi\Builders\ExtensionsBuilder;
 use Vyuldashev\LaravelOpenApi\Builders\Paths\Operation\CallbacksBuilder;
 use Vyuldashev\LaravelOpenApi\Builders\Paths\Operation\ParametersBuilder;
 use Vyuldashev\LaravelOpenApi\Builders\Paths\Operation\RequestBodyBuilder;
 use Vyuldashev\LaravelOpenApi\Builders\Paths\Operation\ResponsesBuilder;
+use Vyuldashev\LaravelOpenApi\Builders\Paths\Operation\SecurityBuilder;
+use Vyuldashev\LaravelOpenApi\Factories\SecuritySchemeFactory;
 use Vyuldashev\LaravelOpenApi\RouteInformation;
 
 class OperationsBuilder
@@ -22,19 +25,22 @@ class OperationsBuilder
     protected RequestBodyBuilder $requestBodyBuilder;
     protected ResponsesBuilder $responsesBuilder;
     protected ExtensionsBuilder $extensionsBuilder;
+    protected SecurityBuilder $securityBuilder;
 
     public function __construct(
         CallbacksBuilder $callbacksBuilder,
         ParametersBuilder $parametersBuilder,
         RequestBodyBuilder $requestBodyBuilder,
         ResponsesBuilder $responsesBuilder,
-        ExtensionsBuilder $extensionsBuilder
+        ExtensionsBuilder $extensionsBuilder,
+        SecurityBuilder $securityBuilder
     ) {
         $this->callbacksBuilder = $callbacksBuilder;
         $this->parametersBuilder = $parametersBuilder;
         $this->requestBodyBuilder = $requestBodyBuilder;
         $this->responsesBuilder = $responsesBuilder;
         $this->extensionsBuilder = $extensionsBuilder;
+        $this->securityBuilder = $securityBuilder;
     }
 
     /**
@@ -54,12 +60,12 @@ class OperationsBuilder
 
             $operationId = optional($operationAttribute)->id;
             $tags = $operationAttribute->tags ?? [];
-            $security = array_map(fn ($s) => SecurityRequirement::create()->securityScheme($s), $operationAttribute->security);
 
             $parameters = $this->parametersBuilder->build($route);
             $requestBody = $this->requestBodyBuilder->build($route);
             $responses = $this->responsesBuilder->build($route);
             $callbacks = $this->callbacksBuilder->build($route);
+            $security = $this->securityBuilder->build($route);
 
             $operation = Operation::create()
                 ->action(Str::lower($operationAttribute->method) ?: $route->method)

--- a/src/Builders/Paths/OperationsBuilder.php
+++ b/src/Builders/Paths/OperationsBuilder.php
@@ -42,7 +42,7 @@ class OperationsBuilder
      * @return array
      * @throws InvalidArgumentException
      */
-    public function build(array|Collection $routes): array
+    public function build(array | Collection $routes): array
     {
         $operations = [];
 
@@ -54,7 +54,7 @@ class OperationsBuilder
 
             $operationId = optional($operationAttribute)->id;
             $tags = $operationAttribute->tags ?? [];
-            $security = array_map(fn ($s) => SecurityRequirement::create()->securityScheme($s), $operationAttribute->security);
+            $security = array_map(fn($s) => SecurityRequirement::create()->securityScheme($s), $operationAttribute->security);
 
             $parameters = $this->parametersBuilder->build($route);
             $requestBody = $this->requestBodyBuilder->build($route);


### PR DESCRIPTION
## Usage

SanctumSecurityScheme:

```php
<?php

namespace App\OpenApi\SecuritySchemes;

use GoldSpecDigital\ObjectOrientedOAS\Objects\SecurityScheme;
use Vyuldashev\LaravelOpenApi\Factories\SecuritySchemeFactory;

class SanctumSecurityScheme extends SecuritySchemeFactory
{
    public function build(): SecurityScheme
    {
        return SecurityScheme::create('Sanctum')
            ->type(SecurityScheme::TYPE_HTTP)
            ->scheme('bearer');
    }
}
```
![image](https://user-images.githubusercontent.com/11737104/110245547-e3915180-7f8d-11eb-812a-fd587a31775a.png)

```php

/**
 * Gets all published car washes.
 *
 * Gets all published car washes as an array.
 */
#[OpenApi\Operation(tags: ['Car Wash'], security: ['Sanctum'])]
#[OpenApi\Parameters(factory: CommonParameters::class)]
public function index()
{
    $list = CarWash::published()
        ->orderBy('name')
        ->get();
    return response()->json($list);
}

```

![image](https://user-images.githubusercontent.com/11737104/110245740-ae393380-7f8e-11eb-9c33-0bb4d8bdec64.png)

