### PR TITLE
Add: contact schema

### DIFF
--- a/config/openapi.php
+++ b/config/openapi.php
@@ -10,7 +10,7 @@ return [
                 'title' => config('app.name'),
                 'description' => null,
                 'version' => '1.0.0',
-                'contact' => []
+                'contact' => [],
             ],
 
             'servers' => [

--- a/config/openapi.php
+++ b/config/openapi.php
@@ -10,6 +10,7 @@ return [
                 'title' => config('app.name'),
                 'description' => null,
                 'version' => '1.0.0',
+                'contact' => []
             ],
 
             'servers' => [

--- a/src/Builders/InfoBuilder.php
+++ b/src/Builders/InfoBuilder.php
@@ -2,9 +2,9 @@
 
 namespace Vyuldashev\LaravelOpenApi\Builders;
 
-use Illuminate\Support\Arr;
-use GoldSpecDigital\ObjectOrientedOAS\Objects\Info;
 use GoldSpecDigital\ObjectOrientedOAS\Objects\Contact;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\Info;
+use Illuminate\Support\Arr;
 
 class InfoBuilder
 {

--- a/src/Builders/InfoBuilder.php
+++ b/src/Builders/InfoBuilder.php
@@ -2,8 +2,9 @@
 
 namespace Vyuldashev\LaravelOpenApi\Builders;
 
-use GoldSpecDigital\ObjectOrientedOAS\Objects\Info;
 use Illuminate\Support\Arr;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\Info;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\Contact;
 
 class InfoBuilder
 {
@@ -14,6 +15,16 @@ class InfoBuilder
             ->description(Arr::get($config, 'description'))
             ->version(Arr::get($config, 'version'));
 
+        if (Arr::has($config, 'contact') &&
+            (
+                array_key_exists('name', $config['contact']) ||
+                array_key_exists('email', $config['contact']) ||
+                array_key_exists('url', $config['contact'])
+            )
+        ) {
+            $info = $info->contact($this->buildContact($config['contact']));
+        }
+
         $extensions = $config['extensions'] ?? [];
 
         foreach ($extensions as $key => $value) {
@@ -21,5 +32,13 @@ class InfoBuilder
         }
 
         return $info;
+    }
+
+    protected function buildContact(array $config): Contact
+    {
+        return Contact::create()
+            ->name(Arr::get($config, 'name'))
+            ->email(Arr::get($config, 'email'))
+            ->url(Arr::get($config, 'url'));
     }
 }

--- a/tests/Builders/InfoBuilderTest.php
+++ b/tests/Builders/InfoBuilderTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vyuldashev\LaravelOpenApi\Tests\Builders;
+
+use Vyuldashev\LaravelOpenApi\Builders\InfoBuilder;
+use Vyuldashev\LaravelOpenApi\Tests\TestCase;
+
+class InfoBuilderTest extends TestCase
+{
+    /**
+     * @dataProvider providerBuildContact
+     * @param array $config
+     * @param array $expected
+     * @return void
+     */
+    public function testBuildContact(array $config, array $expected): void
+    {
+        $SUT = new InfoBuilder();
+        $info = $SUT->build($config);
+        $this->assertSameAssociativeArray($expected, $info->toArray());
+    }
+
+    public function providerBuildContact(): array
+    {
+        $common = [
+            'title' => 'sample_title',
+            'description' => 'sample_description',
+            'version' => 'sample_version',
+        ];
+
+        return [
+            'If all the elements are present, the correct json can be output.'
+                => [
+                    array_merge($common, [
+                        'contact' => [
+                            'name' => 'sample_contact_name',
+                            'email' => 'sample_contact_email',
+                            'url' => 'sample_contact_url',
+                        ],
+                    ]),
+                    array_merge($common, [
+                        'contact' => [
+                            'name' => 'sample_contact_name',
+                            'email' => 'sample_contact_email',
+                            'url' => 'sample_contact_url',
+                        ],
+                    ]),
+                ],
+            'If Contact.name does not exist, the correct json can be output.'
+                => [
+                    array_merge($common, [
+                        'contact' => [
+                            'email' => 'sample_contact_email',
+                            'url' => 'sample_contact_url',
+                        ],
+                    ]),
+                    array_merge($common, [
+                        'contact' => [
+                            'email' => 'sample_contact_email',
+                            'url' => 'sample_contact_url',
+                        ],
+                    ]),
+                ],
+            'If Contact.email does not exist, the correct json can be output.'
+                => [
+                    array_merge($common, [
+                        'contact' => [
+                            'name' => 'sample_contact_name',
+                            'url' => 'sample_contact_url',
+                        ],
+                    ]),
+                    array_merge($common, [
+                        'contact' => [
+                            'name' => 'sample_contact_name',
+                            'url' => 'sample_contact_url',
+                        ],
+                    ]),
+                ],
+            'If Contact.url does not exist, the correct json can be output.'
+                => [
+                    array_merge($common, [
+                        'contact' => [
+                            'name' => 'sample_contact_name',
+                            'email' => 'sample_contact_email',
+                        ],
+                    ]),
+                    array_merge($common, [
+                        'contact' => [
+                            'name' => 'sample_contact_name',
+                            'email' => 'sample_contact_email',
+                        ],
+                    ]),
+                ],
+            'If Contact does not exist, the correct json can be output.'
+                => [
+                    array_merge($common),
+                    array_merge($common),
+                ],
+            'If Contact.* does not exist, the correct json can be output.'
+                => [
+                    array_merge($common, [
+                        'contact' => [],
+                    ]),
+                    array_merge($common),
+                ],
+        ];
+    }
+
+    /**
+     * Assert equality as an associative array
+     *
+     * @param array $expected
+     * @param array $actual
+     * @return void
+     */
+    protected function assertSameAssociativeArray(array $expected, array $actual): void
+    {
+        foreach ($expected as $key => $value) {
+            if (is_array($value)) {
+                $this->assertSameAssociativeArray($value, $actual[$key]);
+                unset($actual[$key]);
+                continue;
+            }
+            self::assertSame($value, $actual[$key]);
+            unset($actual[$key]);
+        }
+        self::assertCount(0, $actual, sprintf('[%s] does not matched keys.', join(', ', array_keys($actual))));
+    }
+}

--- a/tests/Builders/InfoBuilderTest.php
+++ b/tests/Builders/InfoBuilderTest.php
@@ -31,85 +31,79 @@ class InfoBuilderTest extends TestCase
         ];
 
         return [
-            'If all the elements are present, the correct json can be output.'
-                => [
-                    array_merge($common, [
-                        'contact' => [
-                            'name' => 'sample_contact_name',
-                            'email' => 'sample_contact_email',
-                            'url' => 'sample_contact_url',
-                        ],
-                    ]),
-                    array_merge($common, [
-                        'contact' => [
-                            'name' => 'sample_contact_name',
-                            'email' => 'sample_contact_email',
-                            'url' => 'sample_contact_url',
-                        ],
-                    ]),
-                ],
-            'If Contact.name does not exist, the correct json can be output.'
-                => [
-                    array_merge($common, [
-                        'contact' => [
-                            'email' => 'sample_contact_email',
-                            'url' => 'sample_contact_url',
-                        ],
-                    ]),
-                    array_merge($common, [
-                        'contact' => [
-                            'email' => 'sample_contact_email',
-                            'url' => 'sample_contact_url',
-                        ],
-                    ]),
-                ],
-            'If Contact.email does not exist, the correct json can be output.'
-                => [
-                    array_merge($common, [
-                        'contact' => [
-                            'name' => 'sample_contact_name',
-                            'url' => 'sample_contact_url',
-                        ],
-                    ]),
-                    array_merge($common, [
-                        'contact' => [
-                            'name' => 'sample_contact_name',
-                            'url' => 'sample_contact_url',
-                        ],
-                    ]),
-                ],
-            'If Contact.url does not exist, the correct json can be output.'
-                => [
-                    array_merge($common, [
-                        'contact' => [
-                            'name' => 'sample_contact_name',
-                            'email' => 'sample_contact_email',
-                        ],
-                    ]),
-                    array_merge($common, [
-                        'contact' => [
-                            'name' => 'sample_contact_name',
-                            'email' => 'sample_contact_email',
-                        ],
-                    ]),
-                ],
-            'If Contact does not exist, the correct json can be output.'
-                => [
-                    array_merge($common),
-                    array_merge($common),
-                ],
-            'If Contact.* does not exist, the correct json can be output.'
-                => [
-                    array_merge($common, [
-                        'contact' => [],
-                    ]),
-                    array_merge($common),
-                ],
+            'If all the elements are present, the correct json can be output.' => [
+                array_merge($common, [
+                    'contact' => [
+                        'name' => 'sample_contact_name',
+                        'email' => 'sample_contact_email',
+                        'url' => 'sample_contact_url',
+                    ],
+                ]),
+                array_merge($common, [
+                    'contact' => [
+                        'name' => 'sample_contact_name',
+                        'email' => 'sample_contact_email',
+                        'url' => 'sample_contact_url',
+                    ],
+                ]),
+            ],
+            'If Contact.name does not exist, the correct json can be output.' => [
+                array_merge($common, [
+                    'contact' => [
+                        'email' => 'sample_contact_email',
+                        'url' => 'sample_contact_url',
+                    ],
+                ]),
+                array_merge($common, [
+                    'contact' => [
+                        'email' => 'sample_contact_email',
+                        'url' => 'sample_contact_url',
+                    ],
+                ]),
+            ],
+            'If Contact.email does not exist, the correct json can be output.' => [
+                array_merge($common, [
+                    'contact' => [
+                        'name' => 'sample_contact_name',
+                        'url' => 'sample_contact_url',
+                    ],
+                ]),
+                array_merge($common, [
+                    'contact' => [
+                        'name' => 'sample_contact_name',
+                        'url' => 'sample_contact_url',
+                    ],
+                ]),
+            ],
+            'If Contact.url does not exist, the correct json can be output.' => [
+                array_merge($common, [
+                    'contact' => [
+                        'name' => 'sample_contact_name',
+                        'email' => 'sample_contact_email',
+                    ],
+                ]),
+                array_merge($common, [
+                    'contact' => [
+                        'name' => 'sample_contact_name',
+                        'email' => 'sample_contact_email',
+                    ],
+                ]),
+            ],
+            'If Contact does not exist, the correct json can be output.' => [
+                array_merge($common),
+                array_merge($common),
+            ],
+            'If Contact.* does not exist, the correct json can be output.' => [
+                array_merge($common, [
+                    'contact' => [],
+                ]),
+                array_merge($common),
+            ],
         ];
     }
 
     /**
-     * Assert equality as an associative array
+     * Assert equality as an associative array.
      *
      * @param array $expected
      * @param array $actual


### PR DESCRIPTION
In this PR, `config/openapi.php` is modified to enable output of the contact schema.

Example:

```
config/openapi.php
~~~
'info' => [
    'contact' => [
        'name' => 'sample',
        'url' => 'sample_url',
        'email' => 'sample_email',
    ],
],
~~~
```

output json

```
~~~
"info": {
    "contact": {
        "name": "sample",
        "url": "sample_url",
        "email": "sample_email"
    }
},
~~~
```
