### PR TITLE
Use parameter required when building path from route

### DIFF
--- a/config/openapi.php
+++ b/config/openapi.php
@@ -75,4 +75,6 @@ return [
         ],
     ],
 
+    'clone_routes_with_optional_params' => true,
+
 ];

--- a/src/Builders/Paths/Operation/ParametersBuilder.php
+++ b/src/Builders/Paths/Operation/ParametersBuilder.php
@@ -47,7 +47,7 @@ class ParametersBuilder
                     ->first(static fn(Param $param) => Str::snake($param->getVariableName()) === Str::snake($parameter['name']));
 
                 return Parameter::path()->name($parameter['name'])
-                    ->required($parameter['required'] ?? true)
+                    ->required()
                     ->description(optional(optional($description)->getDescription())->render())
                     ->schema($schema);
             })

--- a/src/Builders/Paths/Operation/ParametersBuilder.php
+++ b/src/Builders/Paths/Operation/ParametersBuilder.php
@@ -47,7 +47,7 @@ class ParametersBuilder
                     ->first(static fn(Param $param) => Str::snake($param->getVariableName()) === Str::snake($parameter['name']));
 
                 return Parameter::path()->name($parameter['name'])
-                    ->required()
+                    ->required($parameter['required'] ?? true)
                     ->description(optional(optional($description)->getDescription())->render())
                     ->schema($schema);
             })

--- a/src/Builders/PathsBuilder.php
+++ b/src/Builders/PathsBuilder.php
@@ -87,7 +87,6 @@ class PathsBuilder
 
         if (config('openapi.clone_routes_with_optional_params', false)) {
             $this->cloneRoutesWithOptionalParameters();
-            dd($this->routes);
         }
 
         return $this->routes;


### PR DESCRIPTION
Here is a small modification to support optional route parameters when generating openapi.