### PR TITLE
Generate command improvements and OpenAPI validation

### DIFF
--- a/config/openapi.php
+++ b/config/openapi.php
@@ -75,4 +75,6 @@ return [
         ],
     ],
 
+    'clone_routes_with_optional_params' => true,
+
 ];

--- a/config/openapi.php
+++ b/config/openapi.php
@@ -30,6 +30,13 @@ return [
 
             ],
 
+            'responses' => [
+                [
+                    'code' => 200,
+                    'description' => 'OK',
+                ],
+            ],
+
             'security' => [
                 // GoldSpecDigital\ObjectOrientedOAS\Objects\SecurityRequirement::create()->securityScheme('JWT'),
             ],

--- a/src/Builders/Paths/Operation/ParametersBuilder.php
+++ b/src/Builders/Paths/Operation/ParametersBuilder.php
@@ -47,7 +47,7 @@ class ParametersBuilder
                     ->first(static fn(Param $param) => Str::snake($param->getVariableName()) === Str::snake($parameter['name']));
 
                 return Parameter::path()->name($parameter['name'])
-                    ->required($parameter['required'] ?? true)
+                    ->required()
                     ->description(optional(optional($description)->getDescription())->render())
                     ->schema($schema);
             })

--- a/src/Builders/Paths/Operation/ParametersBuilder.php
+++ b/src/Builders/Paths/Operation/ParametersBuilder.php
@@ -47,7 +47,7 @@ class ParametersBuilder
                     ->first(static fn(Param $param) => Str::snake($param->getVariableName()) === Str::snake($parameter['name']));
 
                 return Parameter::path()->name($parameter['name'])
-                    ->required()
+                    ->required($parameter['required'] ?? true)
                     ->description(optional(optional($description)->getDescription())->render())
                     ->schema($schema);
             })

--- a/src/Builders/Paths/OperationsBuilder.php
+++ b/src/Builders/Paths/OperationsBuilder.php
@@ -4,6 +4,7 @@ namespace Vyuldashev\LaravelOpenApi\Builders\Paths;
 
 use GoldSpecDigital\ObjectOrientedOAS\Exceptions\InvalidArgumentException;
 use GoldSpecDigital\ObjectOrientedOAS\Objects\Operation;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\Response;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Vyuldashev\LaravelOpenApi\Attributes\Operation as OperationAttribute;
@@ -63,6 +64,15 @@ class OperationsBuilder
             $responses = $this->responsesBuilder->build($route);
             $callbacks = $this->callbacksBuilder->build($route);
             $security = $this->securityBuilder->build($route);
+
+            $defaultResponses = config('openapi.collections.default.responses');
+            if (!$responses && $defaultResponses) {
+                $responses = collect($defaultResponses)->map(
+                    fn($response) => Response::create()
+                        ->statusCode($response['code'])
+                        ->description($response['description'])
+                )->toArray();
+            }
 
             $operation = Operation::create()
                 ->action(Str::lower($operationAttribute->method) ?: $route->method)

--- a/src/Builders/PathsBuilder.php
+++ b/src/Builders/PathsBuilder.php
@@ -87,7 +87,6 @@ class PathsBuilder
 
         if (config('openapi.clone_routes_with_optional_params', false)) {
             $this->cloneRoutesWithOptionalParameters();
-            dd($this->routes);
         }
 
         return $this->routes;

--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -4,28 +4,74 @@ declare(strict_types=1);
 
 namespace Vyuldashev\LaravelOpenApi\Console;
 
+use GoldSpecDigital\ObjectOrientedOAS\Exceptions\ValidationException;
+use GoldSpecDigital\ObjectOrientedOAS\OpenApi;
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Symfony\Component\Yaml\Yaml;
 use Vyuldashev\LaravelOpenApi\Generator;
 
 class GenerateCommand extends Command
 {
-    protected $signature = 'openapi:generate {collection=default}';
+    protected $signature = 'openapi:generate {collection=default} {--format=JSON} {--filePath=}';
     protected $description = 'Generate OpenAPI specification';
+
+    protected string $format;
+    protected string $filePath;
+    protected OpenApi $openApi;
 
     public function handle(Generator $generator): void
     {
+        $this->setFormat();
+        $this->setFilePath();
+
         $collectionExists = collect(config('openapi.collections'))->has($this->argument('collection'));
 
         if (! $collectionExists) {
             $this->error('Collection "'.$this->argument('collection').'" does not exist.');
-
             return;
         }
 
-        $this->line(
-            $generator
-                ->generate($this->argument('collection'))
-                ->toJson(JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE)
-        );
+        $this->openApi = $generator->generate($this->argument('collection'));
+
+        $this->line($this->getContents());
+
+        if ($this->filePath) {
+            $this->saveToFile();
+        }
+    }
+
+    protected function saveToFile(): void
+    {
+        Storage::put($this->filePath.'/'.$this->generateFileName(), $this->getContents());
+        $this->info(__('OpenAPI generated in :FORMAT format saved to :filePath', ['format' => $this->format, 'filePath' => storage_path($this->filePath)]));
+    }
+
+    protected function setFormat(): void
+    {
+        $this->format = $this->option('format') ?? 'JSON';
+    }
+
+    protected function setFilePath(): void
+    {
+        $this->filePath = $this->option('filePath') ?? 'openapi';
+    }
+
+    protected function getContents(): string
+    {
+        return match($this->format) {
+            'JSON' => $this->openApi->toJson(JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE),
+            'YAML' => Yaml::dump($this->openApi->toArray(), 6),
+        };
+    }
+
+    private function generateFileName(): string
+    {
+        return collect([
+            Str::of(config('app.name'))->slug(),
+            '-openapi-'.now()->toDateString(),
+            '.'.strtolower($this->format),
+        ])->implode('');
     }
 }


### PR DESCRIPTION
This PR includes improvements to the generator command.

- Save to storage JSON & YAML format supported
- Validates OpenAPI spec currently checks for missing responses
- Default responses applied to every route which have not defined responses
- Additional responses array added to the default collections config

Tested the output from postman and there are no longer any validation errors.