### PR TITLE
Ability to turn off security at operation level

### DIFF
--- a/src/Attributes/Operation.php
+++ b/src/Attributes/Operation.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Vyuldashev\LaravelOpenApi\Attributes;
 
 use Attribute;
@@ -31,10 +30,16 @@ class Operation
         $this->tags = $tags;
         $this->method = $method;
 
-        if ($security) {
-            $this->security = class_exists($security) ? $security : app()->getNamespace().'OpenApi\\SecuritySchemes\\'.$security;
+        if ($security === '') {
+            //user wants to turn off security on this operation
+            $this->security = $security;
+            return;
+        }
 
-            if (! is_a($this->security, SecuritySchemeFactory::class, true)) {
+        if ($security) {
+            $this->security = class_exists($security) ? $security : app()->getNamespace() . 'OpenApi\\SecuritySchemes\\' . $security;
+
+            if (!is_a($this->security, SecuritySchemeFactory::class, true)) {
                 throw new InvalidArgumentException(
                     sprintf('Security class is either not declared or is not an instance of %s', SecuritySchemeFactory::class)
                 );

--- a/src/Attributes/Operation.php
+++ b/src/Attributes/Operation.php
@@ -37,9 +37,9 @@ class Operation
         }
 
         if ($security) {
-            $this->security = class_exists($security) ? $security : app()->getNamespace() . 'OpenApi\\SecuritySchemes\\' . $security;
+            $this->security = class_exists($security) ? $security : app()->getNamespace().'OpenApi\\SecuritySchemes\\'.$security;
 
-            if (!is_a($this->security, SecuritySchemeFactory::class, true)) {
+            if (! is_a($this->security, SecuritySchemeFactory::class, true)) {
                 throw new InvalidArgumentException(
                     sprintf('Security class is either not declared or is not an instance of %s', SecuritySchemeFactory::class)
                 );

--- a/src/Builders/Paths/Operation/SecurityBuilder.php
+++ b/src/Builders/Paths/Operation/SecurityBuilder.php
@@ -1,10 +1,9 @@
 <?php
-
 namespace Vyuldashev\LaravelOpenApi\Builders\Paths\Operation;
 
+use Vyuldashev\LaravelOpenApi\RouteInformation;
 use GoldSpecDigital\ObjectOrientedOAS\Objects\SecurityRequirement;
 use Vyuldashev\LaravelOpenApi\Attributes\Operation as OperationAttribute;
-use Vyuldashev\LaravelOpenApi\RouteInformation;
 
 class SecurityBuilder
 {
@@ -14,6 +13,10 @@ class SecurityBuilder
             ->filter(static fn (object $attribute) => $attribute instanceof OperationAttribute)
             ->filter(static fn (OperationAttribute $attribute) => isset($attribute->security))
             ->map(static function (OperationAttribute $attribute) {
+                // return a null scheme if the security is set to ''
+                if ($attribute->security === '') {
+                    return SecurityRequirement::create()->securityScheme(null);
+                }
                 $security = app($attribute->security);
                 $scheme = $security->build();
 

--- a/src/Builders/Paths/OperationsBuilder.php
+++ b/src/Builders/Paths/OperationsBuilder.php
@@ -1,19 +1,18 @@
 <?php
-
 namespace Vyuldashev\LaravelOpenApi\Builders\Paths;
 
-use GoldSpecDigital\ObjectOrientedOAS\Exceptions\InvalidArgumentException;
-use GoldSpecDigital\ObjectOrientedOAS\Objects\Operation;
-use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
-use Vyuldashev\LaravelOpenApi\Attributes\Operation as OperationAttribute;
-use Vyuldashev\LaravelOpenApi\Builders\ExtensionsBuilder;
-use Vyuldashev\LaravelOpenApi\Builders\Paths\Operation\CallbacksBuilder;
-use Vyuldashev\LaravelOpenApi\Builders\Paths\Operation\ParametersBuilder;
-use Vyuldashev\LaravelOpenApi\Builders\Paths\Operation\RequestBodyBuilder;
-use Vyuldashev\LaravelOpenApi\Builders\Paths\Operation\ResponsesBuilder;
-use Vyuldashev\LaravelOpenApi\Builders\Paths\Operation\SecurityBuilder;
+use Illuminate\Support\Collection;
 use Vyuldashev\LaravelOpenApi\RouteInformation;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\Operation;
+use Vyuldashev\LaravelOpenApi\Builders\ExtensionsBuilder;
+use Vyuldashev\LaravelOpenApi\Builders\Paths\Operation\SecurityBuilder;
+use Vyuldashev\LaravelOpenApi\Builders\Paths\Operation\CallbacksBuilder;
+use Vyuldashev\LaravelOpenApi\Builders\Paths\Operation\ResponsesBuilder;
+use Vyuldashev\LaravelOpenApi\Attributes\Operation as OperationAttribute;
+use Vyuldashev\LaravelOpenApi\Builders\Paths\Operation\ParametersBuilder;
+use GoldSpecDigital\ObjectOrientedOAS\Exceptions\InvalidArgumentException;
+use Vyuldashev\LaravelOpenApi\Builders\Paths\Operation\RequestBodyBuilder;
 
 class OperationsBuilder
 {
@@ -73,8 +72,14 @@ class OperationsBuilder
                 ->parameters(...$parameters)
                 ->requestBody($requestBody)
                 ->responses(...$responses)
-                ->callbacks(...$callbacks)
-                ->security(...$security);
+                ->callbacks(...$callbacks);
+
+            /** Not the cleanest code, we need to call notSecurity instead of security when our security has been turned off */
+            if (count($security) === 1 && $security[0]->securityScheme === null) {
+                $operation = $operation->noSecurity();
+            } else {
+                $operation = $operation->security(...$security);
+            }
 
             $this->extensionsBuilder->build($operation, $route->actionAttributes);
 

--- a/tests/Builders/SecurityBuilderTest.php
+++ b/tests/Builders/SecurityBuilderTest.php
@@ -186,6 +186,7 @@ class SecurityBuilderTest extends TestCase
             'paths' => [
                 '/foo' => [
                     'get' => [
+                        'summary' => 'Test',
                         'security' => [],
                     ],
                 ],

--- a/tests/Builders/SecurityBuilderTest.php
+++ b/tests/Builders/SecurityBuilderTest.php
@@ -1,0 +1,217 @@
+<?php
+namespace Vyuldashev\LaravelOpenApi\Tests\Builders;
+
+use Vyuldashev\LaravelOpenApi\Tests\TestCase;
+use GoldSpecDigital\ObjectOrientedOAS\OpenApi;
+use Vyuldashev\LaravelOpenApi\RouteInformation;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\PathItem;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\Operation;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\Components;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\SecurityScheme;
+use Vyuldashev\LaravelOpenApi\Factories\SecuritySchemeFactory;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\SecurityRequirement;
+use Vyuldashev\LaravelOpenApi\Builders\Paths\Operation\SecurityBuilder;
+use Vyuldashev\LaravelOpenApi\Attributes\Operation as AttributesOperation;
+
+class SecurityBuilderTest extends TestCase
+{
+    /**
+     * We're just making sure we're getting the expected output
+     */
+    public function testWeCanBuildUpTheSecurityScheme(): void
+    {
+        $securityFactory = resolve(JwtSecurityScheme::class);
+        $testJwtScheme = $securityFactory->build();
+
+        $globalRequirement = SecurityRequirement::create('JWT')
+            ->securityScheme($testJwtScheme);
+
+        $components = Components::create()
+            ->securitySchemes($testJwtScheme);
+
+        $operation = Operation::create()
+            ->action('get');
+
+        $openApi = OpenApi::create()
+            ->security($globalRequirement)
+            ->components($components)
+            ->paths(
+                PathItem::create()
+                    ->route('/foo')
+                    ->operations($operation)
+            );
+
+        self::assertSame([
+            'paths' => [
+                '/foo' => [
+                    'get' => [],
+                ],
+            ],
+            'components' => [
+                'securitySchemes' => [
+                    'JWT' => [
+                        'type' => 'http',
+                        'name' => 'TestScheme',
+                        'in' => 'header',
+                        'scheme' => 'bearer',
+                        'bearerFormat' => 'JWT',
+                    ],
+                ],
+            ],
+            'security' => [
+                [
+                    'JWT' => [],
+                ]
+            ]
+        ], $openApi->toArray());
+    }
+
+    /**
+     * We're just verifying that the builder is capable of
+     * adding security information to the operation
+     */
+    public function testWeCanAddOperationSecurityUsingBuilder()
+    {
+        $securityFactory = resolve(JwtSecurityScheme::class);
+        $testJwtScheme = $securityFactory->build();
+
+        $globalRequirement = SecurityRequirement::create('JWT')
+            ->securityScheme($testJwtScheme);
+
+        $components = Components::create()
+            ->securitySchemes($testJwtScheme);
+
+        $routeInfo = new RouteInformation;
+        $routeInfo->action = 'get';
+        $routeInfo->name = 'test route';
+        $routeInfo->actionAttributes = collect([
+            new AttributesOperation(security: JwtSecurityScheme::class),
+        ]);
+        $routeInfo->uri = '/example';
+
+        /** @var SecurityBuilder */
+        $builder = resolve(SecurityBuilder::class);
+
+        $operation = Operation::create()
+            ->security(...$builder->build($routeInfo))
+            ->action('get');
+
+        $openApi = OpenApi::create()
+        ->security($globalRequirement)
+        ->components($components)
+        ->paths(
+            PathItem::create()
+                ->route('/foo')
+                ->operations($operation)
+        );
+
+        self::assertSame([
+            'paths' => [
+                '/foo' => [
+                    'get' => [
+                        'security' => [
+                            [
+                                'JWT' => []
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'components' => [
+                'securitySchemes' => [
+                    'JWT' => [
+                        'type' => 'http',
+                        'name' => 'TestScheme',
+                        'in' => 'header',
+                        'scheme' => 'bearer',
+                        'bearerFormat' => 'JWT',
+                    ],
+                ],
+            ],
+            'security' => [
+                [
+                    'JWT' => [],
+                ]
+            ]
+        ], $openApi->toArray());
+    }
+
+    /**
+     * He's the main part of the PR. It's not possible to turn
+     * off security for an operation.
+     */
+    public function testWeCanAddTurnOffOperationSecurityUsingBuilder()
+    {
+        $securityFactory = resolve(JwtSecurityScheme::class);
+        $testJwtScheme = $securityFactory->build();
+
+        $globalRequirement = SecurityRequirement::create('JWT')
+            ->securityScheme($testJwtScheme);
+
+        $components = Components::create()
+            ->securitySchemes($testJwtScheme);
+
+        $routeInfo = new RouteInformation;
+        $routeInfo->action = 'get';
+        $routeInfo->name = 'test route';
+        $routeInfo->actionAttributes = collect([
+            new AttributesOperation(security: ''),
+        ]);
+        $routeInfo->uri = '/example';
+
+        /** @var SecurityBuilder */
+        $builder = resolve(SecurityBuilder::class);
+
+        $operation = Operation::create()
+            ->security(...$builder->build($routeInfo))
+            ->action('get');
+
+        $openApi = OpenApi::create()
+        ->security($globalRequirement)
+        ->components($components)
+        ->paths(
+            PathItem::create()
+                ->route('/foo')
+                ->operations($operation)
+        );
+
+        self::assertSame([
+            'paths' => [
+                '/foo' => [
+                    'get' => [
+                        'security' => [],
+                    ],
+                ],
+            ],
+            'components' => [
+                'securitySchemes' => [
+                    'JWT' => [
+                        'type' => 'http',
+                        'name' => 'TestScheme',
+                        'in' => 'header',
+                        'scheme' => 'bearer',
+                        'bearerFormat' => 'JWT',
+                    ],
+                ],
+            ],
+            'security' => [
+                [
+                    'JWT' => [],
+                ]
+            ]
+        ], $openApi->toArray());
+    }
+}
+
+class JwtSecurityScheme extends SecuritySchemeFactory
+{
+    public function build(): SecurityScheme
+    {
+        return SecurityScheme::create('JWT')
+            ->name('TestScheme')
+            ->type(SecurityScheme::TYPE_HTTP)
+            ->in(SecurityScheme::IN_HEADER)
+            ->scheme('bearer')
+            ->bearerFormat('JWT');
+    }
+}

--- a/tests/Builders/SecurityBuilderTest.php
+++ b/tests/Builders/SecurityBuilderTest.php
@@ -155,6 +155,11 @@ class SecurityBuilderTest extends TestCase
         $routeInfo->action = 'get';
         $routeInfo->name = 'test route';
         $routeInfo->actionAttributes = collect([
+            /**
+             * we can set secuity to null to turn it off, as
+             * that's the default value. So '' is next best
+             * option?
+            */
             new AttributesOperation(security: ''),
         ]);
         $routeInfo->uri = '/example';


### PR DESCRIPTION
I (don't think?) it's possible to set a root level security requirement, but then turn it off for one or more operations.

I've added a test that shows the problem, then the PR fixes it.

After the PR, you can turn off security for an operation be setting the 'security' paramater to '':

`#[OpenApi\Operation(security: '')]`

Thanks in advance.