### PR TITLE
Move bindings to the register method

### DIFF
--- a/src/OpenApiServiceProvider.php
+++ b/src/OpenApiServiceProvider.php
@@ -20,17 +20,6 @@ use Vyuldashev\LaravelOpenApi\Builders\TagsBuilder;
 
 class OpenApiServiceProvider extends ServiceProvider
 {
-    public function boot(): void
-    {
-        if ($this->app->runningInConsole()) {
-            $this->publishes([
-                __DIR__.'/../config/openapi.php' => config_path('openapi.php'),
-            ], 'openapi-config');
-        }
-
-        $this->loadRoutesFrom(__DIR__.'/../routes/api.php');
-    }
-
     public function register(): void
     {
         $this->mergeConfigFrom(
@@ -86,6 +75,17 @@ class OpenApiServiceProvider extends ServiceProvider
                 Console\SecuritySchemeFactoryMakeCommand::class,
             ]);
         }
+    }
+
+    public function boot(): void
+    {
+        if ($this->app->runningInConsole()) {
+            $this->publishes([
+                __DIR__.'/../config/openapi.php' => config_path('openapi.php'),
+            ], 'openapi-config');
+        }
+
+        $this->loadRoutesFrom(__DIR__.'/../routes/api.php');
     }
 
     private function getPathsFromConfig(string $type): array


### PR DESCRIPTION
Hi!

Bindings (`bind` or `singletone` calls) must be placed in the `register` method.
Docs reference: https://laravel.com/docs/8.x/providers#the-register-method

It will be easier to read this PR by-commit. 