### PR TITLE
feat: allow overriding global servers in Operations

### DIFF
--- a/src/Attributes/Operation.php
+++ b/src/Attributes/Operation.php
@@ -18,6 +18,8 @@ class Operation
 
     public ?string $method;
 
+    public ?array $servers;
+
     /**
      * @param  string|null  $id
      * @param  array  $tags
@@ -26,11 +28,12 @@ class Operation
      *
      * @throws InvalidArgumentException
      */
-    public function __construct(string $id = null, array $tags = [], string $security = null, string $method = null)
+    public function __construct(string $id = null, array $tags = [], string $security = null, string $method = null, array $servers = null)
     {
         $this->id = $id;
         $this->tags = $tags;
         $this->method = $method;
+        $this->servers = $servers;
 
         if ($security === '') {
             //user wants to turn off security on this operation

--- a/src/Factories/ServerFactory.php
+++ b/src/Factories/ServerFactory.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Vyuldashev\LaravelOpenApi\Factories;
+
+use GoldSpecDigital\ObjectOrientedOAS\Objects\Server;
+
+abstract class ServerFactory
+{
+    abstract public function build(): Server;
+}


### PR DESCRIPTION
This implements the servers object in https://swagger.io/specification/#operation-object
allowing you to override the global servers in operations.

### Why

We have an incident api that uploads public incidents to an s3 bucket. That one is publicly accessible.

It's actually a redirect endpoint to the public url, but we want to describe the public url in our OpenAPI.

Code example:

### `app/OpenApi/Servers/PublicServer.php`

```php
<?php

namespace App\OpenApi\Servers;
use GoldSpecDigital\ObjectOrientedOAS\Objects\Server;
use Vyuldashev\LaravelOpenApi\Factories\ServerFactory;

class PublicServer extends ServerFactory
{
    public function build(): Server
    {
        return Server::create()
                ->url("https://public.server")
                ->description('Public server');
    }
}

```

### `app/Domain/StatusPage/Controllers/IncidentPublicController.php`

```php
<?php

namespace App\Domain\StatusPage\Controllers;

use App\Domain\StatusPage\OpenApi\Responses\ListPublicIncidentsResponse;
use App\OpenApi\Responses\UnauthorizedActionResponse;
use App\OpenApi\Servers\PublicServer;
use Illuminate\Routing\Controller;
use Illuminate\Support\Facades\Storage;
use Vyuldashev\LaravelOpenApi\Attributes as OpenApi;

#[OpenApi\PathItem]
class IncidentPublicController extends Controller
{
    public const PUBLIC_PATH = 'status/incidents.json';

    /**
     * Get all published Incidents
     *
     * Display a listing of the published incidents.
     *
     */
    #[OpenApi\Operation(tags: ['incident'], security: '', servers: [PublicServer::class])]
    #[OpenApi\Response(factory: ListPublicIncidentsResponse::class)]
    public function index(): \Illuminate\Routing\Redirector|\Illuminate\Http\RedirectResponse|\Illuminate\Contracts\Foundation\Application
    {

        return redirect(
            Storage::disk('portal')->url(self::PUBLIC_PATH)
        );
    }
}

```