### PR TITLE
Override route paramters

### DIFF
--- a/src/RouteInformation.php
+++ b/src/RouteInformation.php
@@ -83,12 +83,14 @@ class RouteInformation
             $actionAttributes = collect($reflectionMethod->getAttributes())
                 ->map(fn (ReflectionAttribute $attribute) => $attribute->newInstance());
 
+            $containsControllerLevelParamter = $actionAttributes->contains(fn ($value) => $value instanceof \Vyuldashev\LaravelOpenApi\Attributes\Parameters);
+
             $instance->domain = $route->domain();
             $instance->method = $method;
             $instance->uri = Str::start($route->uri(), '/');
             $instance->name = $route->getName();
             $instance->controller = $controller;
-            $instance->parameters = $parameters;
+            $instance->parameters = $containsControllerLevelParamter ? collect([]) : $parameters;
             $instance->controllerAttributes = $controllerAttributes;
             $instance->action = $action;
             $instance->actionParameters = $reflectionMethod->getParameters();


### PR DESCRIPTION
* **What kind of change does this PR introduce?**
Feature

* **What is the current behavior?**
Currently, if there are two parameters defined, one at a route path level `users/{user}`, and the other at a controller level having a parameters class, that would generate two parameters in the OpenAPI YAML/JSON.


* **What is the new behavior (if this is a feature change)?**
The new behavior ignores the route level parameter if there is a controller level parameter. For example, if the route path is `users/{user}` and there is a parameter defined in the controller for that specific path, it would ignore the route path parameter and take the controller level parameter.


* **Does this PR introduce a breaking change?**
No


* **Other information**: