### PR TITLE
Resolution for issue #48. Same occurs in Laravel 9. 

### DIFF
--- a/src/Console/SchemaFactoryMakeCommand.php
+++ b/src/Console/SchemaFactoryMakeCommand.php
@@ -35,7 +35,7 @@ class SchemaFactoryMakeCommand extends GeneratorCommand
 
     protected function buildModel($output, $model)
     {
-        $namespace = app()::VERSION[0] >= 8 ? $this->laravel->getNamespace(). 'Models\\' : $this->laravel->getNamespace();
+        $namespace = app()::VERSION[0] >= 8 ? $this->laravel->getNamespace().'Models\\' : $this->laravel->getNamespace();
         $model = Str::start($model, $namespace);
 
         if (! is_a($model, Model::class, true)) {

--- a/src/Console/SchemaFactoryMakeCommand.php
+++ b/src/Console/SchemaFactoryMakeCommand.php
@@ -35,7 +35,8 @@ class SchemaFactoryMakeCommand extends GeneratorCommand
 
     protected function buildModel($output, $model)
     {
-        $model = Str::start($model, $this->laravel->getNamespace());
+        $namespace = app()::VERSION[0] >= 8 ? $this->laravel->getNamespace(). 'Models\\' : $this->laravel->getNamespace();
+        $model = Str::start($model, $namespace);
 
         if (! is_a($model, Model::class, true)) {
             throw new InvalidArgumentException('Invalid model');


### PR DESCRIPTION
Not sure why not fixed already... original suggestion fixes the issue.

I get the error on a clean install of Laravel 9, so I'd be interested to see the scenarios in which it doesn't break to cross-reference. 