### PR TITLE
Added database prefix logic into the buildModel method.

### DIFF
--- a/src/Console/SchemaFactoryMakeCommand.php
+++ b/src/Console/SchemaFactoryMakeCommand.php
@@ -44,7 +44,7 @@ class SchemaFactoryMakeCommand extends GeneratorCommand
         /** @var Model $model */
         $model = app($model);
 
-        $columns = SchemaFacade::connection($model->getConnectionName())->getColumnListing(config('database.connections.' . config('database.default') . '.prefix', '') . $model->getTable());
+        $columns = SchemaFacade::connection($model->getConnectionName())->getColumnListing(config('database.connections.'.config('database.default').'.prefix', '').$model->getTable());
         $connection = $model->getConnection();
 
         $definition = 'return Schema::object(\''.class_basename($model).'\')'.PHP_EOL;
@@ -53,7 +53,7 @@ class SchemaFactoryMakeCommand extends GeneratorCommand
         $properties = collect($columns)
             ->map(static function ($column) use ($model, $connection) {
                 /** @var Column $column */
-                $column = $connection->getDoctrineColumn(config('database.connections.' . config('database.default') . '.prefix', '') . $model->getTable(), $column);
+                $column = $connection->getDoctrineColumn(config('database.connections.'.config('database.default').'.prefix', '').$model->getTable(), $column);
                 $name = $column->getName();
                 $default = $column->getDefault();
                 $notNull = $column->getNotnull();

--- a/src/Console/SchemaFactoryMakeCommand.php
+++ b/src/Console/SchemaFactoryMakeCommand.php
@@ -44,7 +44,7 @@ class SchemaFactoryMakeCommand extends GeneratorCommand
         /** @var Model $model */
         $model = app($model);
 
-        $columns = SchemaFacade::connection($model->getConnectionName())->getColumnListing($model->getTable());
+        $columns = SchemaFacade::connection($model->getConnectionName())->getColumnListing(config('database.connections.' . config('database.default') . '.prefix', '') . $model->getTable());
         $connection = $model->getConnection();
 
         $definition = 'return Schema::object(\''.class_basename($model).'\')'.PHP_EOL;
@@ -53,7 +53,7 @@ class SchemaFactoryMakeCommand extends GeneratorCommand
         $properties = collect($columns)
             ->map(static function ($column) use ($model, $connection) {
                 /** @var Column $column */
-                $column = $connection->getDoctrineColumn($model->getTable(), $column);
+                $column = $connection->getDoctrineColumn(config('database.connections.' . config('database.default') . '.prefix', '') . $model->getTable(), $column);
                 $name = $column->getName();
                 $default = $column->getDefault();
                 $notNull = $column->getNotnull();


### PR DESCRIPTION
Resolution for issue #67. 

This PR adds database prefix support to the project. 

Structure of Laravel's config/database.php is as follows, I am mearly making use of the default functionality of Laravel. 

https://raw.githubusercontent.com/laravel/laravel/9.x/config/database.php

By default prefix is always set to empty, so this shouldn't affect any current implementations.