### PR TITLE
Feat extensions

### DIFF
--- a/config/openapi.php
+++ b/config/openapi.php
@@ -38,11 +38,11 @@ return [
             'extensions' => [
                 // 'x-tagGroups' => [
                 //     [
-				//         'name' => 'General',
-				//         'tags' => [
-				//             'user',
-				//         ],
-				//     ],
+                //         'name' => 'General',
+                //         'tags' => [
+                //             'user',
+                //         ],
+                //     ],
                 // ],
             ],
 

--- a/config/openapi.php
+++ b/config/openapi.php
@@ -34,6 +34,18 @@ return [
                 // GoldSpecDigital\ObjectOrientedOAS\Objects\SecurityRequirement::create()->securityScheme('JWT'),
             ],
 
+            // Non standard attributes used by code/doc generation tools can be added here
+            'extensions' => [
+                // 'x-tagGroups' => [
+                //     [
+				//         'name' => 'General',
+				//         'tags' => [
+				//             'user',
+				//         ],
+				//     ],
+                // ],
+            ],
+
             // Route for exposing specification.
             // Leave uri null to disable.
             'route' => [

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -48,8 +48,9 @@ class Generator
         $tags = $this->tagsBuilder->build(Arr::get($this->config, 'collections.'.$collection.'.tags', []));
         $paths = $this->pathsBuilder->build($collection, Arr::get($middlewares, 'paths', []));
         $components = $this->componentsBuilder->build($collection, Arr::get($middlewares, 'components', []));
+        $extensions = Arr::get($this->config, 'collections.'.$collection.'.extensions', []);
 
-        return OpenApi::create()
+        $openApi =  OpenApi::create()
             ->openapi(OpenApi::OPENAPI_3_0_2)
             ->info($info)
             ->servers(...$servers)
@@ -57,5 +58,11 @@ class Generator
             ->components($components)
             ->security(...Arr::get($this->config, 'collections.'.$collection.'.security', []))
             ->tags(...$tags);
+
+        foreach ($extensions as $key => $value) {
+            $openApi = $openApi->x($key, $value);
+        }
+
+        return $openApi;
     }
 }

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -50,7 +50,7 @@ class Generator
         $components = $this->componentsBuilder->build($collection, Arr::get($middlewares, 'components', []));
         $extensions = Arr::get($this->config, 'collections.'.$collection.'.extensions', []);
 
-        $openApi =  OpenApi::create()
+        $openApi = OpenApi::create()
             ->openapi(OpenApi::OPENAPI_3_0_2)
             ->info($info)
             ->servers(...$servers)


### PR DESCRIPTION
This PR adds support for custom extension attributes to be added to the root spec. This is particularly useful for configuring doc generation tools like Redocly which I added an example for in the config file.