### PR TITLE
fix: security schema example

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -31,7 +31,7 @@ class UserController extends Controller
      *
      * Creates new user or returns already existing user by email.
      */
-     #[OpenApi\Operation(security: 'BearerToken')]
+     #[OpenApi\Operation(security: 'BearerTokenSecurityScheme')]
     public function store(Request $request)
     {
         //


### PR DESCRIPTION
If run command as below:
```bash
php artisan openapi:make-security-scheme BearerToken
```

command will generate a file:
App\OpenApi\SecuritySchemes\BearerTokenSecurityScheme.php

User will get error message when they follow document

```
   InvalidArgumentException

  Security class is either not declared or is not an instance of Vyuldashev\LaravelOpenApi\Factories\SecuritySchemeFactory

  at vendor/vyuldashev/laravel-openapi/src/Attributes/Operation.php:49
     45▕         if ($security) {
     46▕             $this->security = class_exists($security) ? $security : app()->getNamespace().'OpenApi\\SecuritySchemes\\'.$security;
     47▕
     48▕             if (! is_a($this->security, SecuritySchemeFactory::class, true)) {
  ➜  49▕                 throw new InvalidArgumentException(
     50▕                     sprintf('Security class is either not declared or is not an instance of %s', SecuritySchemeFactory::class)
     51▕                 );
     52▕             }
     53▕         }

  1   app/Http/Controllers/Platform/Tunnel/OrdersController.php:74
      Vyuldashev\LaravelOpenApi\Attributes\Operation::__construct()

      +1 vendor frames
  3   [internal]:0
      Vyuldashev\LaravelOpenApi\RouteInformation::Vyuldashev\LaravelOpenApi\{closure}()
```

Therefore we just fix document example about security schema.
