### PR TITLE
Added nullsafe operator to actionDocBlock in OperationsBuilder

### DIFF
--- a/src/Builders/Paths/OperationsBuilder.php
+++ b/src/Builders/Paths/OperationsBuilder.php
@@ -70,11 +70,14 @@ class OperationsBuilder
             $callbacks = $this->callbacksBuilder->build($route);
             $security = $this->securityBuilder->build($route);
 
+            $description = $route->actionDocBlock?->getDescription()->render();
+            $summary = $route->actionDocBlock?->getSummary();
+
             $operation = Operation::create()
                 ->action(Str::lower($operationAttribute->method) ?: $route->method)
                 ->tags(...$tags)
-                ->description($route->actionDocBlock->getDescription()->render() !== '' ? $route->actionDocBlock->getDescription()->render() : null)
-                ->summary($route->actionDocBlock->getSummary() !== '' ? $route->actionDocBlock->getSummary() : null)
+                ->description(empty($description) ? null : $description)
+                ->summary(empty($summary) ? null : $summary)
                 ->operationId($operationId)
                 ->parameters(...$parameters)
                 ->requestBody($requestBody)


### PR DESCRIPTION
When there is no docblock for a controller function like:

```php
#[OpenApi\Operation]
public function __invoke(): Response
```

You will get the following exception:

```
Call to a member function getSummary() on null {"exception":"[object] (Error(code: 0): Call to a member function getSummary() on null at /var/www/html/vendor/vyuldashev/laravel-openapi/src/Builders/Paths/OperationsBuilder.php:82)
```

This PR fixes that you don't need to have a docblock for your function.