### PR TITLE
Make schema factory work with Laravel 10

### DIFF
--- a/src/Console/SchemaFactoryMakeCommand.php
+++ b/src/Console/SchemaFactoryMakeCommand.php
@@ -35,7 +35,8 @@ class SchemaFactoryMakeCommand extends GeneratorCommand
 
     protected function buildModel($output, $model)
     {
-        $namespace = app()::VERSION[0] >= 8 ? $this->laravel->getNamespace().'Models\\' : $this->laravel->getNamespace();
+        $appVersion = explode('.', app()::VERSION);
+        $namespace = $appVersion[0] >= 8 ? $this->laravel->getNamespace().'Models\\' : $this->laravel->getNamespace();
         $model = Str::start($model, $namespace);
 
         if (! is_a($model, Model::class, true)) {


### PR DESCRIPTION
Hi, the previous fix for checking Laravel version doesn't work with Laravel 10 as it only takes the first version digit into account. Extracting the whole major version part for comparison seems to do the trick.