### PR TITLE
Mark operations deprecated with `@deprecated`

### DIFF
--- a/src/Attributes/Operation.php
+++ b/src/Attributes/Operation.php
@@ -20,6 +20,8 @@ class Operation
 
     public ?array $servers;
 
+    public ?bool $deprecated;
+
     /**
      * @param  string|null  $id
      * @param  array  $tags
@@ -28,12 +30,13 @@ class Operation
      *
      * @throws InvalidArgumentException
      */
-    public function __construct(string $id = null, array $tags = [], string $security = null, string $method = null, array $servers = null)
+    public function __construct(string $id = null, array $tags = [], string $security = null, string $method = null, array $servers = null, bool $deprecated = null)
     {
         $this->id = $id;
         $this->tags = $tags;
         $this->method = $method;
         $this->servers = $servers;
+        $this->deprecated = $deprecated;
 
         if ($security === '') {
             //user wants to turn off security on this operation

--- a/src/Attributes/Operation.php
+++ b/src/Attributes/Operation.php
@@ -20,8 +20,6 @@ class Operation
 
     public ?array $servers;
 
-    public ?bool $deprecated;
-
     /**
      * @param  string|null  $id
      * @param  array  $tags
@@ -30,13 +28,12 @@ class Operation
      *
      * @throws InvalidArgumentException
      */
-    public function __construct(string $id = null, array $tags = [], string $security = null, string $method = null, array $servers = null, bool $deprecated = null)
+    public function __construct(string $id = null, array $tags = [], string $security = null, string $method = null, array $servers = null)
     {
         $this->id = $id;
         $this->tags = $tags;
         $this->method = $method;
         $this->servers = $servers;
-        $this->deprecated = $deprecated;
 
         if ($security === '') {
             //user wants to turn off security on this operation

--- a/src/Builders/Paths/OperationsBuilder.php
+++ b/src/Builders/Paths/OperationsBuilder.php
@@ -73,6 +73,7 @@ class OperationsBuilder
             $operation = Operation::create()
                 ->action(Str::lower($operationAttribute->method) ?: $route->method)
                 ->tags(...$tags)
+                ->deprecated($operationAttribute->deprecated)
                 ->description($route->actionDocBlock->getDescription()->render() !== '' ? $route->actionDocBlock->getDescription()->render() : null)
                 ->summary($route->actionDocBlock->getSummary() !== '' ? $route->actionDocBlock->getSummary() : null)
                 ->operationId($operationId)

--- a/src/Builders/Paths/OperationsBuilder.php
+++ b/src/Builders/Paths/OperationsBuilder.php
@@ -6,6 +6,7 @@ use GoldSpecDigital\ObjectOrientedOAS\Exceptions\InvalidArgumentException;
 use GoldSpecDigital\ObjectOrientedOAS\Objects\Operation;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use phpDocumentor\Reflection\DocBlock;
 use Vyuldashev\LaravelOpenApi\Attributes\Operation as OperationAttribute;
 use Vyuldashev\LaravelOpenApi\Builders\ExtensionsBuilder;
 use Vyuldashev\LaravelOpenApi\Builders\Paths\Operation\CallbacksBuilder;
@@ -73,7 +74,7 @@ class OperationsBuilder
             $operation = Operation::create()
                 ->action(Str::lower($operationAttribute->method) ?: $route->method)
                 ->tags(...$tags)
-                ->deprecated($operationAttribute->deprecated)
+                ->deprecated($this->isDeprecated($route->actionDocBlock))
                 ->description($route->actionDocBlock->getDescription()->render() !== '' ? $route->actionDocBlock->getDescription()->render() : null)
                 ->summary($route->actionDocBlock->getSummary() !== '' ? $route->actionDocBlock->getSummary() : null)
                 ->operationId($operationId)
@@ -96,5 +97,16 @@ class OperationsBuilder
         }
 
         return $operations;
+    }
+
+    protected function isDeprecated(?DocBlock $actionDocBlock): bool
+    {
+        if ($actionDocBlock === null) {
+            return false;
+        }
+
+        $deprecatedTag = $actionDocBlock->getTagsByName('deprecated');
+
+        return count($deprecatedTag) > 0;
     }
 }


### PR DESCRIPTION
This will mark every endpoint deprecated which has `@deprecated` in its docblock.