### PR TITLE
sort collection of component classes

### DIFF
--- a/src/Builders/Components/Builder.php
+++ b/src/Builders/Components/Builder.php
@@ -44,6 +44,7 @@ abstract class Builder
                 return
                     $collectionAttribute->name === ['*'] ||
                     in_array($collection, $collectionAttribute->name ?? [], true);
-            });
+            })
+            ->sort();
     }
 }


### PR DESCRIPTION
We have a check in our github actions, if the generated doku is up to date. So we compare the version we have checked in with a new generated one. 
But the components will be sorted different between the systems. So the ceck fails because the two dokus have the same content but in a different order.
With this new line the componets will have the same order always.