### PR TITLE
repeatable option for callbacks

### DIFF
--- a/src/Attributes/Callback.php
+++ b/src/Attributes/Callback.php
@@ -6,7 +6,7 @@ use Attribute;
 use InvalidArgumentException;
 use Vyuldashev\LaravelOpenApi\Factories\CallbackFactory;
 
-#[Attribute]
+#[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 class Callback
 {
     public string $factory;


### PR DESCRIPTION
# Example of usage:
```php
#[OpenApi\Operation()]
#[OpenApi\Callback(UsersCallback::class)]  <---  multiple use
#[OpenApi\Callback(TasksCallback::class)]  <---  multiple use
public function index(): JsonResponse
{
    return $this->dispatch(new IndexAction());
}
```

# Result:
<img width="841" alt="screenshot" src="https://github.com/vyuldashev/laravel-openapi/assets/5355251/ee7ccde8-227f-4a32-b3ca-c9eb9a952234">
