### PR TITLE
If the DocBlock is missing, throw a clearer error message.

### DIFF
--- a/src/Builders/Paths/Operation/ParametersBuilder.php
+++ b/src/Builders/Paths/Operation/ParametersBuilder.php
@@ -41,9 +41,9 @@ class ParametersBuilder
 
                     $schema = SchemaHelpers::guessFromReflectionType($reflectionParameter->getType());
                 }
-                
+
                 if (is_null($route->actionDocBlock)) {
-                    throw new \Exception('Missing docblock for route: ' . $route->uri);
+                    throw new \Exception('Missing docblock for route: '.$route->uri);
                 }
                 /** @var Param $description */
                 $description = collect($route->actionDocBlock->getTagsByName('param'))

--- a/src/Builders/Paths/Operation/ParametersBuilder.php
+++ b/src/Builders/Paths/Operation/ParametersBuilder.php
@@ -41,7 +41,10 @@ class ParametersBuilder
 
                     $schema = SchemaHelpers::guessFromReflectionType($reflectionParameter->getType());
                 }
-
+                
+                if (is_null($route->actionDocBlock)) {
+                    throw new \Exception('Missing docblock for route: ' . $route->uri);
+                }
                 /** @var Param $description */
                 $description = collect($route->actionDocBlock->getTagsByName('param'))
                     ->first(static fn (Param $param) => Str::snake($param->getVariableName()) === Str::snake($parameter['name']));


### PR DESCRIPTION
Display error message more clearer when missing DocBlock on somewhere

# Before

![bf](https://github.com/vyuldashev/laravel-openapi/assets/963279/b6a1b6b8-b2ea-47a9-bd20-79b4f4562f9d)


# After
![af](https://github.com/vyuldashev/laravel-openapi/assets/963279/0821b8bc-3684-423b-aa07-5594863ecee2)
