### PR TITLE
Add Support for Laravel 11 and Enhance CI Testing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,4 +41,4 @@ jobs:
         run: composer update --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests
-        run: vendor/bin/phpunit --verbose
+        run: vendor/bin/phpunit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: true
       matrix:
         php: ["8.0", "8.1", "8.2", "8.3"]
-        laravel: ["^9.0", "^10.0"]
+        laravel: ["^9.0", "^10.0", "^11.0"]
         exclude:
           - { php: "8.0", laravel: "^10.0"}
           - { php: "8.0", laravel: "^11.0"}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,9 +13,15 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.0, 8.1, 8.2]
+        php: ["8.0", "8.1", "8.2", "8.3"]
+        laravel: ["^9.0", "^10.0"]
+        exclude:
+          - { php: "8.0", laravel: "^10.0"}
+          - { php: "8.0", laravel: "^11.0"}
+          - { php: "8.1", laravel: "^11.0"}
+          - { php: "8.3", laravel: "^9.0"}
 
-    name: PHP ${{ matrix.php }}
+    name: PHP ${{ matrix.php }} / Laravel ${{ matrix.laravel }}
 
     steps:
       - name: Checkout code
@@ -27,6 +33,9 @@ jobs:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip
           coverage: none
+
+      - name: Set laravel version
+        run: composer require "laravel/framework=${{ matrix.laravel }}" --no-update --no-interaction --no-progress
 
       - name: Install dependencies
         run: composer update --prefer-dist --no-interaction --no-progress

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     },
     "require-dev": {
         "orchestra/testbench": "^5.3|^6.0|^7.0|^8.0",
-        "phpunit/phpunit": "^9.5.13"
+        "phpunit/phpunit": "^9.5.13|^10.5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -23,11 +23,11 @@
         "ext-json": "*",
         "doctrine/dbal": "^2.6|^3.0",
         "goldspecdigital/oooas": "^2.7.1",
-        "laravel/framework": "5.8.*|^6.0|^7.0|^8.0|^9.0|^10.0",
+        "laravel/framework": "5.8.*|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
         "phpdocumentor/reflection-docblock": "^5.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^5.3|^6.0|^7.0|^8.0",
+        "orchestra/testbench": "^5.3|^6.0|^7.0|^8.0|^9.0",
         "phpunit/phpunit": "^9.5.13|^10.5"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "phpdocumentor/reflection-docblock": "^5.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^5.3|^6.0|^7.0",
+        "orchestra/testbench": "^5.3|^6.0|^7.0|^8.0",
         "phpunit/phpunit": "^9.5.13"
     },
     "autoload": {

--- a/tests/Builders/InfoBuilderTest.php
+++ b/tests/Builders/InfoBuilderTest.php
@@ -40,8 +40,8 @@ class InfoBuilderTest extends TestCase
                         'url' => 'sample_contact_url',
                     ],
                     'license' => [
-                        'name'=>'sample_license_name',
-                        'url'=>'sample_license_url',
+                        'name' => 'sample_license_name',
+                        'url' => 'sample_license_url',
                     ],
                 ]),
                 array_merge($common, [
@@ -51,8 +51,8 @@ class InfoBuilderTest extends TestCase
                         'url' => 'sample_contact_url',
                     ],
                     'license' => [
-                        'name'=>'sample_license_name',
-                        'url'=>'sample_license_url',
+                        'name' => 'sample_license_name',
+                        'url' => 'sample_license_url',
                     ],
                 ]),
             ],
@@ -63,8 +63,8 @@ class InfoBuilderTest extends TestCase
                         'url' => 'sample_contact_url',
                     ],
                     'license' => [
-                        'name'=>'sample_license_name',
-                        'url'=>'sample_license_url',
+                        'name' => 'sample_license_name',
+                        'url' => 'sample_license_url',
                     ],
                 ]),
                 array_merge($common, [
@@ -73,8 +73,8 @@ class InfoBuilderTest extends TestCase
                         'url' => 'sample_contact_url',
                     ],
                     'license' => [
-                        'name'=>'sample_license_name',
-                        'url'=>'sample_license_url',
+                        'name' => 'sample_license_name',
+                        'url' => 'sample_license_url',
                     ],
                 ]),
             ],
@@ -85,8 +85,8 @@ class InfoBuilderTest extends TestCase
                         'url' => 'sample_contact_url',
                     ],
                     'license' => [
-                        'name'=>'sample_license_name',
-                        'url'=>'sample_license_url',
+                        'name' => 'sample_license_name',
+                        'url' => 'sample_license_url',
                     ],
                 ]),
                 array_merge($common, [
@@ -95,8 +95,8 @@ class InfoBuilderTest extends TestCase
                         'url' => 'sample_contact_url',
                     ],
                     'license' => [
-                        'name'=>'sample_license_name',
-                        'url'=>'sample_license_url',
+                        'name' => 'sample_license_name',
+                        'url' => 'sample_license_url',
                     ],
                 ]),
             ],
@@ -107,8 +107,8 @@ class InfoBuilderTest extends TestCase
                         'email' => 'sample_contact_email',
                     ],
                     'license' => [
-                        'name'=>'sample_license_name',
-                        'url'=>'sample_license_url',
+                        'name' => 'sample_license_name',
+                        'url' => 'sample_license_url',
                     ],
                 ]),
                 array_merge($common, [
@@ -117,22 +117,22 @@ class InfoBuilderTest extends TestCase
                         'email' => 'sample_contact_email',
                     ],
                     'license' => [
-                        'name'=>'sample_license_name',
-                        'url'=>'sample_license_url',
+                        'name' => 'sample_license_name',
+                        'url' => 'sample_license_url',
                     ],
                 ]),
             ],
             'If Contact does not exist, the correct json can be output.' => [
                 array_merge($common, [
                     'license' => [
-                        'name'=>'sample_license_name',
-                        'url'=>'sample_license_url',
+                        'name' => 'sample_license_name',
+                        'url' => 'sample_license_url',
                     ],
                 ]),
                 array_merge($common, [
                     'license' => [
-                        'name'=>'sample_license_name',
-                        'url'=>'sample_license_url',
+                        'name' => 'sample_license_name',
+                        'url' => 'sample_license_url',
                     ],
                 ]),
             ],
@@ -140,14 +140,14 @@ class InfoBuilderTest extends TestCase
                 array_merge($common, [
                     'contact' => [],
                     'license' => [
-                        'name'=>'sample_license_name',
-                        'url'=>'sample_license_url',
+                        'name' => 'sample_license_name',
+                        'url' => 'sample_license_url',
                     ],
                 ]),
                 array_merge($common, [
                     'license' => [
-                        'name'=>'sample_license_name',
-                        'url'=>'sample_license_url',
+                        'name' => 'sample_license_name',
+                        'url' => 'sample_license_url',
                     ],
                 ]),
             ],
@@ -160,7 +160,7 @@ class InfoBuilderTest extends TestCase
                         'url' => 'sample_contact_url',
                     ],
                     'license' => [
-                        'url'=>'sample_license_url',
+                        'url' => 'sample_license_url',
                     ],
                 ]),
                 array_merge($common, [
@@ -179,7 +179,7 @@ class InfoBuilderTest extends TestCase
                         'url' => 'sample_contact_url',
                     ],
                     'license' => [
-                        'name'=>'sample_license_name',
+                        'name' => 'sample_license_name',
                     ],
                 ]),
                 array_merge($common, [
@@ -189,7 +189,7 @@ class InfoBuilderTest extends TestCase
                         'url' => 'sample_contact_url',
                     ],
                     'license' => [
-                        'name'=>'sample_license_name',
+                        'name' => 'sample_license_name',
                     ],
                 ]),
             ],

--- a/tests/Builders/InfoBuilderTest.php
+++ b/tests/Builders/InfoBuilderTest.php
@@ -23,7 +23,7 @@ class InfoBuilderTest extends TestCase
         $this->assertSameAssociativeArray($expected, $info->toArray());
     }
 
-    public function providerBuildContact(): array
+    public static function providerBuildContact(): array
     {
         $common = [
             'title' => 'sample_title',

--- a/tests/Builders/ServersBuilderTest.php
+++ b/tests/Builders/ServersBuilderTest.php
@@ -23,7 +23,7 @@ class ServersBuilderTest extends TestCase
         $this->assertSameAssociativeArray($expected[0], $servers[0]->toArray());
     }
 
-    public function providerBuild(): array
+    public static function providerBuild(): array
     {
         return [
             'If the variables field does not exist, it is possible to output the correct json.' => [

--- a/tests/Builders/TagsBuilderTest.php
+++ b/tests/Builders/TagsBuilderTest.php
@@ -23,7 +23,7 @@ class TagsBuilderTest extends TestCase
         $this->assertSameAssociativeArray($expected[0], $tags[0]->toArray());
     }
 
-    public function providerBuild(): array
+    public static function providerBuild(): array
     {
         return [
             'If the external docs do not exist, it can output the correct json.' => [


### PR DESCRIPTION
Laravel 11 ~~will be~~ has been released. Accordingly, this pull request provides support for the new version and CI enhancements.

closes #112 

## List of changes

* Added support for Laravel 11
* Enhancement of CI
   * Expansion of PHP versions: `8.3` has been newly added in addition to `8.0 - 8.2`.
   * Multiple Laravel versions: Tested on 3 versions: `9.x - 11.x`.
* Fixed points due to support addition
   * `orchestral/testbench` version expansion: Laravel 11 requires Testbench 9.x
   * `phpunit/phpunit` version expansion: Testbench 9.x requires PHPUnit 10
   * Fixed some tests: [Changes in PHPUnit 10.0](https://github.com/sebastianbergmann/phpunit/blob/10.0.0/ChangeLog-10.0.md#changed)
     > Using a non-static method as a data provider is now deprecated

No code modifications were made except for the deprecation of PHPUnit. Under these conditions, I confirmed that all eight combinations of PHP and Laravel versions passed the test without any problems. The results can be seen [here](https://github.com/KentarouTakeda/vyuldashev-laravel-openapi/actions/runs/7780860312/job/21214256127).

I look forward to your feedback and reviews. Thank you for your consideration.