### PR TITLE
Adding check to confirm if the object is of type ReflectionNamedType.

### DIFF
--- a/src/Builders/Paths/Operation/ParametersBuilder.php
+++ b/src/Builders/Paths/Operation/ParametersBuilder.php
@@ -39,7 +39,9 @@ class ParametersBuilder
                         return null;
                     }
 
-                    $schema = SchemaHelpers::guessFromReflectionType($reflectionParameter->getType());
+                    if ($reflectionParameter->getType() instanceof \ReflectionNamedType) {
+                        $schema = SchemaHelpers::guessFromReflectionType($reflectionParameter->getType());
+                    }
                 }
 
                 /** @var Param $description */


### PR DESCRIPTION
Adding a check to prevent the system from trying to look for the ->getType() method in classes of the type, when a ReflectionUnionType or ReflectionType type is returned, it ends up breaking the build because these classes do not have the getType() method.
This generally happens when in the controller method the parameter received has more than one expected type (int|null).